### PR TITLE
Change course API to 2.2.1

### DIFF
--- a/ios-app/AppDelegate.swift
+++ b/ios-app/AppDelegate.swift
@@ -104,7 +104,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             userDefaults.set(true, forKey: Constants.LAUNCHED_APP_BEFORE)
             userDefaults.synchronize() // Forces the app to update UserDefaults
         }
-        let config = Realm.Configuration(schemaVersion: 1)
+        let config = Realm.Configuration(schemaVersion: 2)
         Realm.Configuration.defaultConfiguration = config
         let viewController:UIViewController
         

--- a/ios-app/Model/AttemptSection.swift
+++ b/ios-app/Model/AttemptSection.swift
@@ -33,8 +33,10 @@ public class AttemptSection {
     var startUrl: String!
     var endUrl: String!
     var remainingTime: String!
-    var info: SectionInfo!
     var attemptId: Int!
+    var name: String!
+    var duration: String!
+    var order: Int!
     
     public required init?(map: Map) {
     }
@@ -49,7 +51,9 @@ extension AttemptSection: TestpressModel {
         startUrl <- map["start_url"]
         endUrl <- map["end_url"]
         remainingTime <- map["remaining_time"]
-        info <- map["info"]
         attemptId <- map["attempt_id"]
+        name <- map["name"]
+        duration <- map["duration"]
+        order <- map["order"]
     }
 }

--- a/ios-app/Model/Course.swift
+++ b/ios-app/Model/Course.swift
@@ -43,7 +43,9 @@ class Course: DBModel {
     @objc dynamic var contentsCount = 0
     @objc dynamic var order = 0
     @objc dynamic var active = true
-    
+    @objc dynamic var external_content_link: String = ""
+    @objc dynamic var external_link_label: String = ""
+
     public override func mapping(map: Map) {
         url <- map["url"]
         id <- map["id"]
@@ -59,6 +61,8 @@ class Course: DBModel {
         contentsCount <- map["contents_count"]
         order <- map["order"]
         active <- map["active"]
+        external_content_link <- map["external_content_link"]
+        external_link_label <- map["external_link_label"]
     }
     
     override public static func primaryKey() -> String? {

--- a/ios-app/Network/TPEndpoint.swift
+++ b/ios-app/Network/TPEndpoint.swift
@@ -154,7 +154,7 @@ enum TPEndpoint {
         case .endExam:
             return "end/"
         case .getCourses:
-            return "/api/v2.2/courses/"
+            return "/api/v2.2.1/courses/"
         case .getChapters:
             return "chapters/"
         case .getProfile:

--- a/ios-app/UI/TestEngineViewController.swift
+++ b/ios-app/UI/TestEngineViewController.swift
@@ -69,7 +69,7 @@ class TestEngineViewController: BaseQuestionsPageViewController {
                 if sections[i].state == Attempt.RUNNING {
                     currentSection = i
                 }
-                if sections[i].info.duration == nil || sections[i].info.duration == "0:00:00" {
+                if sections[i].duration == nil || sections[i].duration == "0:00:00" {
                     unlockedSectionExam = true;
                 }
             }
@@ -90,7 +90,7 @@ class TestEngineViewController: BaseQuestionsPageViewController {
                 cell.initCell(index: index, sectionName: item, selectedItem: selectedItemIndex!)
             }
             for section in sections {
-                plainDropDown.items.append(section.info.name)
+                plainDropDown.items.append(section.name)
             }
             plainDropDown.addItems(items: plainDropDown.items)
             plainDropDown.setCurrentItem(index: currentSection)
@@ -212,7 +212,7 @@ class TestEngineViewController: BaseQuestionsPageViewController {
             var currentSpinnerItem: String
             let currentAttemptItem = attemptItems[getCurrentIndex()]
             if unlockedSectionExam {
-                currentSpinnerItem = currentAttemptItem.attemptSection.info.name
+                currentSpinnerItem = currentAttemptItem.attemptSection.name
             } else {
                 currentSpinnerItem = currentAttemptItem.question.subject
             }
@@ -565,7 +565,7 @@ extension TestEngineViewController: QuestionsPageViewDelegate {
             var groupedAttemptItems = OrderedDictionary<String, [AttemptItem]>()
             for attemptItem in attemptItems {
                 if unlockedSectionExam {
-                    let section = attemptItem.attemptSection.info.name!
+                    let section = attemptItem.attemptSection.name!
                     groupAttemptItems(
                         spinnerItem: section,
                         attemptItem: attemptItem,


### PR DESCRIPTION
### Changes done
- Change course API to 2.2.1

### Reason for the changes
- Course API 2.2 is not being used anymore