### PR TITLE
Logout user on HTTP 401 code

### DIFF
--- a/ios-app/Network/TPApiClient.swift
+++ b/ios-app/Network/TPApiClient.swift
@@ -91,6 +91,22 @@ class TPApiClient {
                     if (statusCode == 403) {
                         error = TPError(message: json, response: httpResponse,
                                         kind: .unauthenticated)
+                    } else if (statusCode == 401){
+                        error = TPError(message: json, response: httpResponse, kind: .unauthenticated)
+                        UIUtils.logout()
+
+                        if var topController = UIApplication.shared.keyWindow?.rootViewController {
+                            while let presentedViewController = topController.presentedViewController {
+                                topController = presentedViewController
+                            }
+                            let storyboard = UIStoryboard(name: Constants.MAIN_STORYBOARD, bundle: nil)
+                            let loginViewController = storyboard.instantiateViewController(withIdentifier:
+                                                        Constants.LOGIN_VIEW_CONTROLLER) as! LoginViewController
+                            
+                            topController.present(loginViewController, animated: true, completion: nil)
+                            
+                        }
+                        
                     } else {
                         error = TPError(message: json, response: httpResponse, kind: .http)
                     }

--- a/ios-app/UI/ProfileViewController.swift
+++ b/ios-app/UI/ProfileViewController.swift
@@ -131,27 +131,7 @@ class ProfileViewController: UIViewController {
             style: UIAlertActionStyle.destructive,
             handler: { action in
                 
-                let fcmToken = UserDefaults.standard.string(forKey: Constants.FCM_TOKEN)
-                let deviceToken = UserDefaults.standard.string(forKey: Constants.DEVICE_TOKEN)
-                
-                if (fcmToken != nil && deviceToken != nil ) {
-                    let parameters: Parameters = [
-                        "device_id": deviceToken!,
-                        "registration_id": fcmToken!,
-                        "platform": "ios"
-                    ]
-                    
-                    TPApiClient.apiCall(endpointProvider: TPEndpointProvider(.unRegisterDevice), parameters: parameters,
-                                        completion: { _, _ in})
-                }
-                UIApplication.shared.unregisterForRemoteNotifications()
-
-                // Clear only user related tables
-                DBInstance.clearTables()
-                TPApiClient.apiCall(endpointProvider: TPEndpointProvider(.logout), completion: {_,_ in})
-                // Logout on Facebook
-                LoginManager().logOut()
-                KeychainTokenItem.clearKeychainItems()
+                UIUtils.logout()
                 let loginViewController = self.storyboard?.instantiateViewController(withIdentifier:
                     Constants.LOGIN_VIEW_CONTROLLER) as! LoginViewController
                 

--- a/ios-app/Utils/UIUtils.swift
+++ b/ios-app/Utils/UIUtils.swift
@@ -24,6 +24,8 @@
 //
 
 import UIKit
+import Alamofire
+import FacebookLogin
 
 public class UIUtils {
 
@@ -420,4 +422,28 @@ public class UIUtils {
             let countryDialingCode = prefix[countryRegionCode]
             return countryDialingCode!
         }
+    
+    static func logout() {
+        let fcmToken = UserDefaults.standard.string(forKey: Constants.FCM_TOKEN)
+        let deviceToken = UserDefaults.standard.string(forKey: Constants.DEVICE_TOKEN)
+        
+        if (fcmToken != nil && deviceToken != nil ) {
+            let parameters: Parameters = [
+                "device_id": deviceToken!,
+                "registration_id": fcmToken!,
+                "platform": "ios"
+            ]
+            
+            TPApiClient.apiCall(endpointProvider: TPEndpointProvider(.unRegisterDevice), parameters: parameters,
+                                completion: { _, _ in})
+        }
+        UIApplication.shared.unregisterForRemoteNotifications()
+        
+        // Clear only user related tables
+        DBInstance.clearTables()
+        TPApiClient.apiCall(endpointProvider: TPEndpointProvider(.logout), completion: {_,_ in})
+        // Logout on Facebook
+        LoginManager().logOut()
+        KeychainTokenItem.clearKeychainItems()
+    }
 }


### PR DESCRIPTION
Logout user on HTTP 401 code. Since all further requests will fail after 401, it makes more sense to logout user.