### PR TITLE
Fix video content attempt for every 3 seconds

### DIFF
--- a/ios-app/Network/TPEndpoint.swift
+++ b/ios-app/Network/TPEndpoint.swift
@@ -226,7 +226,7 @@ enum TPEndpoint {
         case .logoutDevices:
             return "/api/v2.4/auth/logout_devices/"
         case .userVideos:
-            return "/api/v2.3/user_videos/"
+            return "/api/v2.4/user_videos/"
         default:
             return ""
         }

--- a/ios-app/UI/RelatedContentsCell.swift
+++ b/ios-app/UI/RelatedContentsCell.swift
@@ -87,6 +87,7 @@ class RelatedContentsCell: UITableViewCell {
         
         if (content?.video != nil && content!.video!.embedCode.isEmpty) {
             if let viewController = self.parentViewController as? VideoContentViewController {
+                viewController.updateVideoAttempt()
                 viewController.changeVideo(content: content)
                 return
             }

--- a/ios-app/UI/VideoContentViewController.swift
+++ b/ios-app/UI/VideoContentViewController.swift
@@ -239,7 +239,6 @@ class VideoContentViewController: UIViewController,UITableViewDelegate, UITableV
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        viewModel.startPeriodicAttemptUpdater()
         addObservers()
         videoPlayerView.addObservers()
         
@@ -255,11 +254,16 @@ class VideoContentViewController: UIViewController,UITableViewDelegate, UITableV
         NotificationCenter.default.addObserver(self, selector: #selector(handleExternalDisplay), name: .UIScreenDidConnect, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleExternalDisplay), name: .UIScreenDidDisconnect, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground), name: .UIApplicationWillEnterForeground, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateVideoAttempt), name: .UIApplicationWillResignActive, object: nil)
 
         
         if #available(iOS 11.0, *) {
             NotificationCenter.default.addObserver(self, selector: #selector(handleScreenCapture), name: .UIScreenCapturedDidChange, object: nil)
         }
+    }
+    
+    @objc func updateVideoAttempt() {
+        viewModel.updateVideoAttempt()
     }
     
     @objc func willEnterForeground() {
@@ -281,7 +285,7 @@ class VideoContentViewController: UIViewController,UITableViewDelegate, UITableV
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        viewModel.stopPeriodicAttemptUpdater()
+        viewModel.updateVideoAttempt()
         videoPlayerView.dealloc()
 
         if let contentDetailPageViewController = self.parent?.parent as? ContentDetailPageViewController {

--- a/ios-app/ViewModel/VideoContentViewModel.swift
+++ b/ios-app/ViewModel/VideoContentViewModel.swift
@@ -25,15 +25,6 @@ class VideoContentViewModel {
         self.content = content
     }
     
-    func startPeriodicAttemptUpdater() {
-        timer?.invalidate()
-        timer = Timer.scheduledTimer(timeInterval: 3.0, target: self, selector: #selector(self.updateVideoAttempt), userInfo: nil, repeats: true)
-    }
-    
-    func stopPeriodicAttemptUpdater() {
-        timer?.invalidate()
-    }
-    
     func getTitle() -> String{
         return content!.name
     }
@@ -82,15 +73,11 @@ class VideoContentViewModel {
                 "time_ranges": [[videoPlayerView!.startTime, currentTime]]
             ]
             let url = TPEndpointProvider.getVideoAttemptPath(attemptID: contentAttemptId!)
-            
             TPApiClient.apiCall(endpointProvider: TPEndpointProvider(.put, url: url), parameters: parameters,completion: {
                 videoAttempt, error in
                 if let error = error {
                     debugPrint(error.message ?? "No error")
                     debugPrint(error.kind)
-                    let event = Event(level: .error)
-                    event.message = error.message ?? "No error"
-                    Client.shared?.send(event: event)
                     return
                 }
             })


### PR DESCRIPTION
### Changes done
- Removed video content attempt update for every 3 seconds
- Video content attempt will be updated only when app goes to the background or user presses the back button
- Changed video content attempt API to 2.4 since 2.3 is depreciated
