### PR TITLE
Fix playback speed reset bug on minimize/play pause

### DIFF
--- a/ios-app/Views/VideoPlayerView.swift
+++ b/ios-app/Views/VideoPlayerView.swift
@@ -20,6 +20,7 @@ class VideoPlayerView: UIView {
     var timeObserver: Any?
     var videoEndObserver: Any?
     var startTime: Float = 0.0
+    var currentPlaybackSpeed: Float = 0.0
     var resolutionInfo:[VideoQuality] = [VideoQuality(resolution:"Auto", bitrate: 0)]
     
     required init?(coder aDecoder: NSCoder) {
@@ -59,6 +60,7 @@ class VideoPlayerView: UIView {
         player?.replaceCurrentItem(with: playerItem)
         player?.seek(to: CMTime.zero)
         player?.rate = 1
+        currentPlaybackSpeed = 1
         play()
         
         if #available(iOS 10.0, *) {
@@ -168,8 +170,8 @@ class VideoPlayerView: UIView {
     }
     
     func changePlaybackSpeed(speed: PlaybackSpeed) {
-        player?.rate = speed.value
-        controlsContainerView.playerStatus = .playing
+        currentPlaybackSpeed = speed.value
+        play()
     }
     
     func pause() {
@@ -178,7 +180,7 @@ class VideoPlayerView: UIView {
     }
     
     func play() {
-        player?.play()
+        player?.rate = currentPlaybackSpeed
         controlsContainerView.playerStatus = .playing
     }
     

--- a/ios-appTests/Views/VideoPlayerViewTest.swift
+++ b/ios-appTests/Views/VideoPlayerViewTest.swift
@@ -37,4 +37,24 @@ class TestVideoPlayerView: XCTestCase {
         
         XCTAssertTrue(UIDevice.current.orientation.isLandscape)
     }
+    
+    func testPlayVideoShouldSetCurrentPlaybackSpeedAs1() {
+        videoPlayerView.playVideo(url: URL(string: "http://google.com")!)
+        
+        XCTAssertEqual(1.0, videoPlayerView.currentPlaybackSpeed)
+    }
+    
+    func testChangePlaybackSpeedShouldSetCurrentPlaybackSpeed() {
+        
+        videoPlayerView.changePlaybackSpeed(speed: PlaybackSpeed.double)
+        
+        XCTAssertEqual(PlaybackSpeed.double.value, videoPlayerView.currentPlaybackSpeed)
+    }
+    
+    func testPlayShouldUseCurrentPlaybackSpeed() {
+        videoPlayerView.currentPlaybackSpeed = 5.0
+        videoPlayerView.play()
+        
+        XCTAssertEqual(5.0, videoPlayerView.getCurrenPlaybackSpeed())
+    }
 }


### PR DESCRIPTION
- After changing playback speed if user pauses and again plays or minimizes and opens the app, the playback speed is reset.
- The above is because we use play method of AVPlayer which will reset playback speed to 1
- So now instead of directly using play method, we store current playback speed and whenever a video plays we use the stored playback speed