### PR TITLE
Fix video displayed as black issue

### DIFF
--- a/ios-app/Repository/EncryptionKeyRepository.swift
+++ b/ios-app/Repository/EncryptionKeyRepository.swift
@@ -13,14 +13,8 @@ import SwiftKeychainWrapper
 class EncryptionKeyRepository {
     func load(url: URL, onSuccess: @escaping(Data) -> Void) {
         let encryptionKeyUrl = URLUtils.convertURLSchemeToHttps(url: url)
-        let key: Data? = getKey(url: encryptionKeyUrl.absoluteString)
-        
-        if (key != nil) {
-            onSuccess(key!)
-        } else {
-            fetchFromNetwork(url: encryptionKeyUrl) { _ in
-                onSuccess(self.getKey(url: encryptionKeyUrl.absoluteString)!)
-            }
+        fetchFromNetwork(url: encryptionKeyUrl) { key in
+            onSuccess(key)
         }
     }
     

--- a/ios-app/Repository/EncryptionKeyRepository.swift
+++ b/ios-app/Repository/EncryptionKeyRepository.swift
@@ -18,21 +18,12 @@ class EncryptionKeyRepository {
         }
     }
     
-    private func getKey(url: String) -> Data? {
-        return KeychainWrapper.standard.data(forKey: url)
-    }
-    
-    private func storeKey(url: String, key: Data) {
-        KeychainWrapper.standard.set(key, forKey: url)
-    }
-    
     private func fetchFromNetwork(url: URL, onSuccess: @escaping(Data) -> Void) {
         var request = URLRequest(url: url)
         request.setValue("JWT " + KeychainTokenItem.getToken(), forHTTPHeaderField: "Authorization")
         let session = URLSession(configuration: URLSessionConfiguration.default)
         let task = session.dataTask(with: request) { data, response, _ in
             guard let key = data else { return }
-            self.storeKey(url: url.absoluteString, key: key)
             onSuccess(key)
         }
         task.resume()


### PR DESCRIPTION
- Issue is we are storing encryption keys for each video in the keychain to reduce requests to server. But in backend if a video is retranscoded then, video url will be same but key will be different. So in that case iOS app won't fetch a new key as it has already stored key for the same video URL.
- So because of using incorrect encryption key, video is displayed as black.