### PR TITLE
Display error if user attends additional question in JEE exam

### DIFF
--- a/ios-app/Model/ApiError.swift
+++ b/ios-app/Model/ApiError.swift
@@ -23,3 +23,29 @@ extension ApiError: TestpressModel {
         detail <- map["detail"]
     }
 }
+
+
+public class TestpressAPIError: TestpressModel {
+    var detail: ErrorDetail?
+    
+    public required init?(map: Map) {
+    }
+    
+    public func mapping(map: Map) {
+        detail <- map["detail"]
+    }
+}
+
+
+class ErrorDetail: TestpressModel {
+    var error_code: String?
+    var message: String?
+    
+    public required init?(map: Map) {
+    }
+    
+    public func mapping(map: Map) {
+        error_code <- map["error_code"]
+        message <- map["message"]
+    }
+}

--- a/ios-app/Model/TPError.swift
+++ b/ios-app/Model/TPError.swift
@@ -63,16 +63,23 @@ public class TPError: Error {
         self.kind = kind
 
 
-        if let error_detail = self.getErrorBodyAs(type: TestpressAPIError.self), error_detail.detail?.error_code != nil {
-            self.kind = Kind.custom
-            self.error_detail = error_detail.detail?.message
-            self.error_code = error_detail.detail?.error_code
+        if isCustomError() {
+            let error = self.getErrorBodyAs(type: TestpressAPIError.self)?.detail
+            self.populateErrorData(code: error?.message, detail: error?.error_code)
         } else if let error_detail = self.getErrorBodyAs(type: ApiError.self) {
-            self.kind = Kind.custom
-            self.error_detail = error_detail.detail
-            self.error_code = error_detail.error_code
+            self.populateErrorData(code: error_detail.detail, detail: error_detail.error_code)
         }
         
+    }
+    
+    func isCustomError() -> Bool {
+        return self.getErrorBodyAs(type: TestpressAPIError.self) != nil
+    }
+    
+    func populateErrorData(code: String?, detail: String?) {
+        self.kind = Kind.custom
+        self.error_detail = detail
+        self.error_code = code
     }
     
     public func isNetworkError() -> Bool {

--- a/ios-app/Model/TPError.swift
+++ b/ios-app/Model/TPError.swift
@@ -62,12 +62,15 @@ public class TPError: Error {
         self.response = response
         self.kind = kind
 
-        if let error_detail = self.getErrorBodyAs(type: ApiError.self) {
-            if (error_detail.detail != nil) {
-                self.kind = Kind.custom
-                self.error_detail = error_detail.detail
-                self.error_code = error_detail.error_code
-            }
+
+        if let error_detail = self.getErrorBodyAs(type: TestpressAPIError.self), error_detail.detail?.error_code != nil {
+            self.kind = Kind.custom
+            self.error_detail = error_detail.detail?.message
+            self.error_code = error_detail.detail?.error_code
+        } else if let error_detail = self.getErrorBodyAs(type: ApiError.self) {
+            self.kind = Kind.custom
+            self.error_detail = error_detail.detail
+            self.error_code = error_detail.error_code
         }
         
     }

--- a/ios-app/UI/TestEngineViewController.swift
+++ b/ios-app/UI/TestEngineViewController.swift
@@ -291,9 +291,15 @@ class TestEngineViewController: BaseQuestionsPageViewController {
                 completion: {
                     newAttemptItem, error in
                     if let error = error {
-                        self.showAlert(error: error, retryHandler: {
-                            self.saveAnswer(index: index, completionHandler: completionHandler)
-                        })
+                        
+                        if error.error_code == "max_attemptable_questions_limit_reached" {
+                            self.showMaxQuestionsAttemptedError(error: error)
+                            self.setCurrentQuestion(index: index)
+                        } else {
+                            self.showAlert(error: error, retryHandler: {
+                                self.saveAnswer(index: index, completionHandler: completionHandler)
+                            })
+                        }
                         return
                     }
                     
@@ -322,6 +328,31 @@ class TestEngineViewController: BaseQuestionsPageViewController {
                 completionHandler!()
             }
         }
+    }
+    
+    func showMaxQuestionsAttemptedError(error: TPError) {
+        if showingProgress {
+            hideLoadingProgress(completionHandler: {
+                self.showAlert(error: error, retryHandler: {})
+            })
+            return
+        }
+        
+        var alert: UIAlertController
+        var cancelButtonTitle: String
+        
+        alert = UIAlertController(
+            title: "Maximum questions attempted",
+            message: error.error_detail,
+            preferredStyle: UIAlertController.Style.alert
+        )
+        cancelButtonTitle = "OK"
+        
+        alert.addAction(UIAlertAction(
+            title: cancelButtonTitle, style: UIAlertAction.Style.default
+        ))
+        
+        present(alert, animated: true, completion: nil)
     }
     
     func endSection() {


### PR DESCRIPTION
- If server throws "max_attemptable_questions_limit_reached" then last attempted question should be cleared and error should be displayed to user that they have attempted maximum number of questions required for that section.