### PR TITLE
Fix end exam not working if max attendable questions is set

### DIFF
--- a/ios-app/UI/BaseQuestionsPageViewController.swift
+++ b/ios-app/UI/BaseQuestionsPageViewController.swift
@@ -189,8 +189,7 @@ class BaseQuestionsPageViewController: UIViewController, UIPageViewControllerDel
     
     func setCurrentQuestion(index: Int) {
         let currentIndex: Int = getCurrentIndex()
-        if  index < 0 || index >= (baseQuestionsDataSource?.attemptItems.count)! ||
-                index == currentIndex {
+        if  index < 0 || index >= (baseQuestionsDataSource?.attemptItems.count)! {
             
             return
         }

--- a/ios-app/UI/TestEngineViewController.swift
+++ b/ios-app/UI/TestEngineViewController.swift
@@ -332,13 +332,6 @@ class TestEngineViewController: BaseQuestionsPageViewController {
     }
     
     func showMaxQuestionsAttemptedError(error: TPError) {
-        if showingProgress {
-            hideLoadingProgress(completionHandler: {
-                self.showAlert(error: error, retryHandler: {})
-            })
-            return
-        }
-        
         var alert: UIAlertController
         var cancelButtonTitle: String
         
@@ -353,7 +346,13 @@ class TestEngineViewController: BaseQuestionsPageViewController {
             title: cancelButtonTitle, style: UIAlertAction.Style.default
         ))
         
-        present(alert, animated: true, completion: nil)
+        if showingProgress {
+            hideLoadingProgress(completionHandler: {
+                self.present(alert, animated: true, completion: nil)
+            })
+        } else {
+            present(alert, animated: true, completion: nil)
+        }
     }
     
     func endSection() {


### PR DESCRIPTION
- Issue is we while ending exam if max restriction on question error occurs then we are showing default exam error alert, which invalidates timer.
- This is fixed by showing Maximum question restrictions error dialog
- Another issue fixed is refreshing the same question view to unselect the selected options