### PR TITLE
Support DRM protected video playback

### DIFF
--- a/ios-app.xcodeproj/project.pbxproj
+++ b/ios-app.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		254D8F1225813D90001A54FE /* MobileRTC.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 254D8F1125813D8F001A54FE /* MobileRTC.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		254E69C421DCF199009A4E61 /* Testpress_iOS_AppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254E69C321DCF199009A4E61 /* Testpress_iOS_AppUITests.swift */; };
 		2555A0C42466A59400D56707 /* ContentsListResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2555A0C32466A59400D56707 /* ContentsListResponse.swift */; };
+		2566A5952745102F00D9E71D /* DRMLicenseKeyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2566A5942745102E00D9E71D /* DRMLicenseKeyResponse.swift */; };
 		25681BD0252F1D69002352E8 /* MobileRTCResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 25681BCF252F1D68002352E8 /* MobileRTCResources.bundle */; };
 		25681BD1252F1DB6002352E8 /* MobileRTC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25681BCD252F1D4A002352E8 /* MobileRTC.framework */; };
 		256A909C247D03C100F4E12C /* IntArrayTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256A909B247D03C100F4E12C /* IntArrayTransform.swift */; };
@@ -67,6 +68,7 @@
 		257BB695246AB4C900524D2C /* QuizExamViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257BB694246AB4C900524D2C /* QuizExamViewController.swift */; };
 		257BB697246AC22B00524D2C /* ExamQuestionsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257BB696246AC22B00524D2C /* ExamQuestionsResponse.swift */; };
 		257BB699246AC2ED00524D2C /* ExamQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257BB698246AC2ED00524D2C /* ExamQuestion.swift */; };
+		258036A52743AA2400397639 /* DRMKeySessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 258036A42743AA2400397639 /* DRMKeySessionDelegate.swift */; };
 		2590B1FA2510BB90003C0A03 /* VideoConference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2590B1F92510BB90003C0A03 /* VideoConference.swift */; };
 		2590B1FC2510C9F2003C0A03 /* VideoConferenceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2590B1FB2510C9F2003C0A03 /* VideoConferenceViewController.swift */; };
 		2592868A2473B1E00035EBA4 /* QuizReviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259286892473B1E00035EBA4 /* QuizReviewViewController.swift */; };
@@ -437,6 +439,7 @@
 		254E69C321DCF199009A4E61 /* Testpress_iOS_AppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Testpress_iOS_AppUITests.swift; sourceTree = "<group>"; };
 		254E69C521DCF199009A4E61 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2555A0C32466A59400D56707 /* ContentsListResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentsListResponse.swift; sourceTree = "<group>"; };
+		2566A5942745102E00D9E71D /* DRMLicenseKeyResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRMLicenseKeyResponse.swift; sourceTree = "<group>"; };
 		25681BCD252F1D4A002352E8 /* MobileRTC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileRTC.framework; path = "../Downloads/ios-mobilertc-all-5.0.24433.0616-clientlog/lib/MobileRTC.framework"; sourceTree = "<group>"; };
 		25681BCF252F1D68002352E8 /* MobileRTCResources.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = MobileRTCResources.bundle; path = "../Downloads/ios-mobilertc-all-5.0.24433.0616-clientlog/lib/MobileRTCResources.bundle"; sourceTree = "<group>"; };
 		256A909B247D03C100F4E12C /* IntArrayTransform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntArrayTransform.swift; sourceTree = "<group>"; };
@@ -464,6 +467,7 @@
 		257BB694246AB4C900524D2C /* QuizExamViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizExamViewController.swift; sourceTree = "<group>"; };
 		257BB696246AC22B00524D2C /* ExamQuestionsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExamQuestionsResponse.swift; sourceTree = "<group>"; };
 		257BB698246AC2ED00524D2C /* ExamQuestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExamQuestion.swift; sourceTree = "<group>"; };
+		258036A42743AA2400397639 /* DRMKeySessionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRMKeySessionDelegate.swift; sourceTree = "<group>"; };
 		2590B1F92510BB90003C0A03 /* VideoConference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoConference.swift; sourceTree = "<group>"; };
 		2590B1FB2510C9F2003C0A03 /* VideoConferenceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoConferenceViewController.swift; sourceTree = "<group>"; };
 		259286892473B1E00035EBA4 /* QuizReviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizReviewViewController.swift; sourceTree = "<group>"; };
@@ -1222,6 +1226,7 @@
 				2590B1FB2510C9F2003C0A03 /* VideoConferenceViewController.swift */,
 				250888D9251C5EC80023DCF6 /* ZoomMeetViewController.swift */,
 				25E435BA263AD8CC00243FD3 /* DashboardViewController.swift */,
+				258036A42743AA2400397639 /* DRMKeySessionDelegate.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -1276,6 +1281,7 @@
 				257BB698246AC2ED00524D2C /* ExamQuestion.swift */,
 				2590B1F92510BB90003C0A03 /* VideoConference.swift */,
 				253DD67D262860B200C6D0A8 /* GapFillResponse.swift */,
+				2566A5942745102E00D9E71D /* DRMLicenseKeyResponse.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1732,6 +1738,7 @@
 				2F48C80D1FD28902009C686C /* PostTableViewCell.swift in Sources */,
 				25705017246E48BA00E6C688 /* ListTransform.swift in Sources */,
 				2F9699781FC2A202001B2B18 /* ContentsTableViewController.swift in Sources */,
+				258036A52743AA2400397639 /* DRMKeySessionDelegate.swift in Sources */,
 				2F25D560201F085A00C01CCE /* LeaderboardTableViewCell.swift in Sources */,
 				2F48C8031FCE9A37009C686C /* CommentPager.swift in Sources */,
 				2FEDFF5C206CF3340002CF04 /* RecentPostTableViewController.swift in Sources */,
@@ -1858,6 +1865,7 @@
 				2F3A53011FDA652A00C64123 /* Subject.swift in Sources */,
 				25985837248A77F6003591FA /* M3U8Handler.swift in Sources */,
 				2FA9285020B7DF2200CD3076 /* StringExtension.swift in Sources */,
+				2566A5952745102F00D9E71D /* DRMLicenseKeyResponse.swift in Sources */,
 				8C2E7B5923979E5A00BA2F41 /* VideoPlayerView.swift in Sources */,
 				2F48C7FF1FCE9750009C686C /* Comment.swift in Sources */,
 				25F92A20243306A60084ADC8 /* UIViewController.swift in Sources */,
@@ -2134,7 +2142,7 @@
 					"$(PROJECT_DIR)",
 				);
 				INFOPLIST_FILE = "ios-app/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.20.0;
 				OTHER_LDFLAGS = (
@@ -2161,7 +2169,7 @@
 					"$(PROJECT_DIR)",
 				);
 				INFOPLIST_FILE = "ios-app/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.20.0;
 				OTHER_LDFLAGS = (

--- a/ios-app/AppDelegate.swift
+++ b/ios-app/AppDelegate.swift
@@ -123,7 +123,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             ]
         }
         
-        let config = Realm.Configuration(schemaVersion: 21)
+        let config = Realm.Configuration(schemaVersion: 22)
         Realm.Configuration.defaultConfiguration = config
         let viewController:UIViewController
         

--- a/ios-app/Extensions/Collection.swift
+++ b/ios-app/Extensions/Collection.swift
@@ -13,3 +13,9 @@ extension Optional where Wrapped: Collection {
         return self?.isEmpty ?? true
     }    
 }
+
+extension Collection {
+    public var isNotEmpty: Bool {
+        return !self.isEmpty
+    }
+}

--- a/ios-app/Model/DRMLicenseKeyResponse.swift
+++ b/ios-app/Model/DRMLicenseKeyResponse.swift
@@ -1,0 +1,15 @@
+import ObjectMapper
+
+public class DRMLicenseKeyResponse {
+    
+    var licenseURL: String!
+
+    public required init?(map: Map) {
+    }
+}
+
+extension DRMLicenseKeyResponse: TestpressModel {
+    public func mapping(map: Map) {
+        licenseURL <- map["license_url"]
+    }
+}

--- a/ios-app/Model/InstituteSettings.swift
+++ b/ios-app/Model/InstituteSettings.swift
@@ -60,6 +60,7 @@ class InstituteSettings: DBModel {
     @objc dynamic var cooloffTime: String = ""
     @objc dynamic var appToolbarLogo: String = ""
     @objc dynamic var customRegistrationEnabled: Bool = false
+    @objc dynamic var fairplayCertificateUrl: String = ""
 
     public override func mapping(map: Map) {
         verificationMethod <- map["verification_method"]
@@ -92,6 +93,7 @@ class InstituteSettings: DBModel {
         cooloffTime <- map["cooloff_time"]
         appToolbarLogo <- map["app_toolbar_logo"]
         customRegistrationEnabled <- map["custom_registration_enabled"]
+        fairplayCertificateUrl <- map["fairplay_certificate_url"]
     }
     
     override public static func primaryKey() -> String? {

--- a/ios-app/Model/Streams.swift
+++ b/ios-app/Model/Streams.swift
@@ -10,12 +10,14 @@ import ObjectMapper
 
 class Stream: DBModel {
     @objc dynamic var url: String = ""
+    @objc dynamic var hlsUrl: String = ""
     @objc dynamic var id: Int = -1
     @objc dynamic var format: String = ""
     @objc dynamic var videoId: Int = -1
     
     public override func mapping(map: Map) {
         url <- map["url"]
+        hlsUrl <- map["hls_url"]
         id <- map["id"]
         format <- map["format"]
         videoId <- map["video_id"]

--- a/ios-app/Model/Video.swift
+++ b/ios-app/Model/Video.swift
@@ -35,13 +35,22 @@ class Video: DBModel {
     @objc dynamic var duration: String = ""
 
     var streams = List<Stream>()
-
     
     func getHlsUrl() -> String {
-        let hls = self.streams.first{
-            $0.format == "HLS"
+        if let hlsURL = self.streams.first(where: {$0.hlsUrl.isNotEmpty}) {
+            return hlsURL.hlsUrl
         }
-        return hls?.url ?? self.url
+        
+        if let hls = self.streams.first(where: {$0.format == "HLS"}) {
+            return hls.url
+        }
+        return self.url
+    }
+    
+    var isDRMProtected: Bool {
+        get {
+            return self.streams.contains(where: {$0.hlsUrl.isNotEmpty})
+        }
     }
     
     override public static func primaryKey() -> String? {

--- a/ios-app/Network/TPEndpoint.swift
+++ b/ios-app/Network/TPEndpoint.swift
@@ -300,4 +300,7 @@ struct TPEndpointProvider {
         return Constants.BASE_URL + TPEndpoint.userVideos.urlPath + "\(attemptID)/"
     }
     
+    static func getDRMLicenseURL(contentID: Int) -> String {
+        return Constants.BASE_URL + "/api/v2.5/chapter_contents/\(contentID)/drm_license/"
+    }
 }

--- a/ios-app/UI/DRMKeySessionDelegate.swift
+++ b/ios-app/UI/DRMKeySessionDelegate.swift
@@ -62,14 +62,6 @@ class DRMKeySessionDelegate: NSObject, AVContentKeySessionDelegate {
         return applicationCertificate!
     }
     
-    func getLicenseURL(completion: @escaping(String?, TPError?) -> Void) {
-        let parameters: Parameters = ["drm_type": "fairplay"]
-        
-        TPApiClient.request(type: DRMLicenseKeyResponse.self, endpointProvider: TPEndpointProvider(.post, url: drmLicenseURL!), parameters: parameters) { response, error in
-            completion(response?.licenseURL, error)
-        }
-    }
-    
     func requestContentKeyFromKeySecurityModule(spcData: Data, assetID: String, completion: @escaping(Data?) -> Void)  {
         let contentKeyIdentifierURL = URL(string: assetID)
         let assetIDString = contentKeyIdentifierURL!.host
@@ -88,6 +80,14 @@ class DRMKeySessionDelegate: NSObject, AVContentKeySessionDelegate {
                 _ = semaphore.wait(timeout: .distantFuture)
                 completion(data)
             }
+        }
+    }
+    
+    func getLicenseURL(completion: @escaping(String?, TPError?) -> Void) {
+        let parameters: Parameters = ["drm_type": "fairplay"]
+        
+        TPApiClient.request(type: DRMLicenseKeyResponse.self, endpointProvider: TPEndpointProvider(.post, url: drmLicenseURL!), parameters: parameters) { response, error in
+            completion(response?.licenseURL, error)
         }
     }
     

--- a/ios-app/UI/DRMKeySessionDelegate.swift
+++ b/ios-app/UI/DRMKeySessionDelegate.swift
@@ -1,0 +1,112 @@
+import Foundation
+import AVKit
+import Alamofire
+
+
+class DRMKeySessionDelegate: NSObject, AVContentKeySessionDelegate {
+    let drmLicenseURL: String?
+    let instituteSettings = DBManager<InstituteSettings>().getResultsFromDB()[0]
+    
+    public required init?(drmLicenseURL: String?) {
+        self.drmLicenseURL = drmLicenseURL
+    }
+    
+    @available(iOS 10.3, *)
+    func contentKeySession(_ session: AVContentKeySession, didProvide keyRequest: AVContentKeyRequest) {
+        
+        guard let contentId = keyRequest.identifier as? String else {
+            keyRequest.processContentKeyResponseError(DRMError.noContentId)
+            return
+        }
+        
+        fetchDRMKey(keyRequest, contentId)
+    }
+    
+    
+    func fetchDRMKey(_ keyRequest: AVContentKeyRequest, _ contentId: String) {
+        let contentIdData = contentId.data(using: String.Encoding.utf8)
+
+        do {
+            let certificateData = try getFairplayCertificateData()
+            keyRequest.makeStreamingContentKeyRequestData(forApp: certificateData, contentIdentifier: contentIdData, options: [AVAssetResourceLoadingRequestStreamingContentKeyRequestRequiresPersistentKey: true as AnyObject]) { spcData, spcError in
+                
+                guard let spcData = spcData else {
+                    let error = spcError ?? DRMError.noSPCData
+                    keyRequest.processContentKeyResponseError(error)
+                    return
+                }
+                
+                self.requestContentKeyFromKeySecurityModule(spcData: spcData, assetID: contentId) {
+                    data in
+                    
+                    let keyResponse = AVContentKeyResponse(fairPlayStreamingKeyResponseData: data!)
+                    keyRequest.processContentKeyResponse(keyResponse)
+                }
+                
+            }
+            
+        } catch {
+            return keyRequest.processContentKeyResponseError(DRMError.licenseError)
+        }
+    }
+    
+    func getFairplayCertificateData() throws -> Data {
+        let certUrl = URL(string: instituteSettings.fairplayCertificateUrl)
+        var applicationCertificate: Data? = nil
+        do {
+            applicationCertificate = try Data(contentsOf:certUrl!)
+        } catch {
+            throw DRMError.certificateError
+        }
+        
+        return applicationCertificate!
+    }
+    
+    func getLicenseURL(completion: @escaping(String?, TPError?) -> Void) {
+        let parameters: Parameters = ["drm_type": "fairplay"]
+        
+        TPApiClient.request(type: DRMLicenseKeyResponse.self, endpointProvider: TPEndpointProvider(.post, url: drmLicenseURL!), parameters: parameters) { response, error in
+            completion(response?.licenseURL, error)
+        }
+    }
+    
+    func requestContentKeyFromKeySecurityModule(spcData: Data, assetID: String, completion: @escaping(Data?) -> Void)  {
+        let contentKeyIdentifierURL = URL(string: assetID)
+        let assetIDString = contentKeyIdentifierURL!.host
+        
+        self.getLicenseURL() { licenseURL, error in
+            if (licenseURL != nil) {
+                var data: Data?
+                let semaphore = DispatchSemaphore(value: 0)
+                let parameters = ["spc": spcData.base64EncodedString(), "assetId" : assetIDString] as [String : Any]
+                let request = self.getLicenseKeyRequest(licenseURL: licenseURL!, parameters: parameters)
+                let dataTask = URLSession.shared.dataTask(with: request as URLRequest) {
+                    data = $0; _ = $1; _ = $2
+                    semaphore.signal()
+                }
+                dataTask.resume()
+                _ = semaphore.wait(timeout: .distantFuture)
+                completion(data)
+            }
+        }
+    }
+    
+    func getLicenseKeyRequest(licenseURL: String, parameters: [String: Any]) -> URLRequest {
+        var request = URLRequest(url: URL(string: licenseURL)!)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("application/octet-stream", forHTTPHeaderField: "Accept")
+        do {
+            try request.httpBody = try JSONSerialization.data(withJSONObject: parameters, options: .prettyPrinted)
+        } catch {}
+        return request
+    }
+}
+
+
+enum DRMError: Error {
+    case noContentId
+    case noSPCData
+    case certificateError
+    case licenseError
+}

--- a/ios-app/UI/VideoContentViewController.swift
+++ b/ios-app/UI/VideoContentViewController.swift
@@ -202,7 +202,8 @@ class VideoContentViewController: UIViewController,UITableViewDelegate, UITableV
     
     func initVideoPlayerView() {
         let playerFrame = CGRect(x: view.frame.origin.x, y: view.frame.origin.y, width: view.frame.width, height: videoPlayer.frame.height)
-        videoPlayerView = VideoPlayerView(frame: playerFrame, url: URL(string: content.video!.getHlsUrl())!)
+        let drmLicenseURL = content.video?.isDRMProtected == true ? TPEndpointProvider.getDRMLicenseURL(contentID: content.id) : nil
+        videoPlayerView = VideoPlayerView(frame: playerFrame, url: URL(string: content.video!.getHlsUrl())!, drmLicenseURL: drmLicenseURL)
         videoPlayerView.playerDelegate = self
     }
     

--- a/ios-app/UI/VideoPlayerResourceLoaderDelegate.swift
+++ b/ios-app/UI/VideoPlayerResourceLoaderDelegate.swift
@@ -11,6 +11,12 @@ import AVKit
 
 
 class VideoPlayerResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate {
+    var contentKeySession: AVContentKeySession?
+
+    func setContentKeySession(contentKeySession: AVContentKeySession) {
+        self.contentKeySession = contentKeySession
+    }
+    
     func resourceLoader(_ resourceLoader: AVAssetResourceLoader, shouldWaitForLoadingOfRequestedResource loadingRequest: AVAssetResourceLoadingRequest) -> Bool {
         guard let url = loadingRequest.request.url else { return false }
         if url.scheme == "fakehttps" {
@@ -18,6 +24,10 @@ class VideoPlayerResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate
                 self.setM3U8Response(loadingRequest: loadingRequest, data: data, response: response)
             }
             return true
+        } else if url.scheme == "skd" {
+            if #available(iOS 11, *) {
+                contentKeySession?.processContentKeyRequest(withIdentifier: url, initializationData: nil, options: nil)
+            }
         } else if isEncryptionKeyUrl(url: url) {
             EncryptionKeyRepository().load(url: url) { data in
                 self.setEncryptionKeyResponse(loadingRequest: loadingRequest, data: data)

--- a/ios-app/Utils/M3U8Handler.swift
+++ b/ios-app/Utils/M3U8Handler.swift
@@ -33,7 +33,7 @@ class M3U8Handler {
          */
         var m3u8DataString = String(data: m3u8Data, encoding: .utf8)!
         
-        if m3u8DataString.contains("EXT-X-KEY") {
+        if m3u8DataString.contains("EXT-X-KEY:METHOD=AES-128") {
             let keyURLStartIndex = m3u8DataString.range(of: "URI=\"")!.upperBound
             let keyURLEndIndex = m3u8DataString[keyURLStartIndex...].range(of: "\"")!.lowerBound
             let keyUrl = m3u8DataString[keyURLStartIndex..<keyURLEndIndex]
@@ -57,8 +57,11 @@ class M3U8Handler {
         let m3u8DataString = String(data: m3u8Data, encoding: .utf8)!
         let baseUrlWithFilenameAndExtension:NSString = url.path as NSString
         let relativeVideoUrl = baseUrlWithFilenameAndExtension.deletingLastPathComponent
-        let modifiedData = m3u8DataString.replacingOccurrences(
+        var modifiedData = m3u8DataString.replacingOccurrences(
             of: "(#EXTINF:[0-9.]*,\n)", with: String(format: "$1 https://%@%@/", url.host!, relativeVideoUrl), options: .regularExpression
+        )
+        modifiedData = modifiedData.replacingOccurrences(
+            of: "#EXT-X-MAP:URI=\"(.*?)\"", with: String(format: "#EXT-X-MAP:URI=\"https://%@%@/%@\"", url.host!, relativeVideoUrl, "$1"), options: .regularExpression
         )
         return modifiedData.data(using: .utf8)!
     }


### PR DESCRIPTION
- Added `fairplayCertificateUrl` in institute model
- When AVPlayer plays video, VideoPlayerResourceLoaderDelegate will check if key url is proper URL. Since DRM protected video's key url is not proper url (i.e skd:content_id), it will call DRMKeySessionDelegate's callback method.
- DRMKeySessionDelegate will create SPC (Secure playback context) request and POST it to license URL. License URL will return CKC (Content Key Context)
- CKC will be provided back to AVPlayer to play the video