### PR TITLE
fix: Send customer key to zoom join API

### DIFF
--- a/ios-app/UI/ZoomMeetViewController.swift
+++ b/ios-app/UI/ZoomMeetViewController.swift
@@ -137,6 +137,7 @@ class ZoomMeetViewController: UIViewController, MobileRTCAuthDelegate, MobileRTC
             service.customizeMeetingTitle(meetingTitle)
             let joinParams = MobileRTCMeetingJoinParam()
             joinParams.userName = KeychainTokenItem.getAccount()
+            joinParams.customerKey = KeychainTokenItem.getAccount()
             joinParams.meetingNumber = meetingNumber
             joinParams.password = password
             service.joinMeeting(with: joinParams)


### PR DESCRIPTION
- This customer key parameter will be sent back when we access zoom reports, so we can use this to uniquely identify user
