### PR TITLE
fix: Fix questions getting shuffled in the review page

### DIFF
--- a/ios-app/UI/BaseQuestionsPageViewController.swift
+++ b/ios-app/UI/BaseQuestionsPageViewController.swift
@@ -132,7 +132,7 @@ class BaseQuestionsPageViewController: UIViewController, UIPageViewControllerDel
                         })
                         return
                     }
-                    self.attemptItems = self.attemptItems.sorted(by: { $0.order < $1.order })
+                    self.attemptItems = self.getAttemptItems()
                     if self.questionsPageViewDelegate?.questionsDidLoad != nil {
                         self.questionsPageViewDelegate?.questionsDidLoad!()
                     }
@@ -154,6 +154,10 @@ class BaseQuestionsPageViewController: UIViewController, UIPageViewControllerDel
                 }
             }
         )
+    }
+    
+    func getAttemptItems() -> Array<AttemptItem > {
+        return self.attemptItems.sorted(by: { $0.order < $1.order })
     }
     
     // MARK: - UIPageViewController delegate methods

--- a/ios-app/UI/BaseQuestionsPageViewController.swift
+++ b/ios-app/UI/BaseQuestionsPageViewController.swift
@@ -132,7 +132,7 @@ class BaseQuestionsPageViewController: UIViewController, UIPageViewControllerDel
                         })
                         return
                     }
-                    self.attemptItems = self.getAttemptItems()
+                    self.attemptItems = self.getSortedAttemptItems()
                     if self.questionsPageViewDelegate?.questionsDidLoad != nil {
                         self.questionsPageViewDelegate?.questionsDidLoad!()
                     }
@@ -156,7 +156,7 @@ class BaseQuestionsPageViewController: UIViewController, UIPageViewControllerDel
         )
     }
     
-    func getAttemptItems() -> Array<AttemptItem > {
+    func getSortedAttemptItems() -> Array<AttemptItem > {
         return self.attemptItems.sorted(by: { $0.order < $1.order })
     }
     

--- a/ios-app/UI/ReviewSolutionsViewController.swift
+++ b/ios-app/UI/ReviewSolutionsViewController.swift
@@ -38,7 +38,7 @@ class ReviewSolutionsViewController: BaseQuestionsPageViewController {
         return ReviewQuestionsDataSource(attemptItems)
     }
     
-    override func getAttemptItems() -> Array<AttemptItem > {
+    override func getSortedAttemptItems() -> Array<AttemptItem > {
         return self.attemptItems
     }
     

--- a/ios-app/UI/ReviewSolutionsViewController.swift
+++ b/ios-app/UI/ReviewSolutionsViewController.swift
@@ -38,6 +38,10 @@ class ReviewSolutionsViewController: BaseQuestionsPageViewController {
         return ReviewQuestionsDataSource(attemptItems)
     }
     
+    override func getAttemptItems() -> Array<AttemptItem > {
+        return self.attemptItems
+    }
+    
 }
 
 extension ReviewSolutionsViewController: QuestionsPageViewDelegate {


### PR DESCRIPTION
- The issue is while reviewing the questions after the attempt questions are not in order that students have attended the exam.
- This is fixed by showing the questions in the order that students have attempted on the review page.