### PR TITLE
Fix app crash on opening chapters

### DIFF
--- a/ios-app.xcodeproj/project.pbxproj
+++ b/ios-app.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		257BB697246AC22B00524D2C /* ExamQuestionsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257BB696246AC22B00524D2C /* ExamQuestionsResponse.swift */; };
 		257BB699246AC2ED00524D2C /* ExamQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257BB698246AC2ED00524D2C /* ExamQuestion.swift */; };
 		258036A52743AA2400397639 /* DRMKeySessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 258036A42743AA2400397639 /* DRMKeySessionDelegate.swift */; };
+		2586782728ABB81700E149B5 /* Object.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2586782628ABB81700E149B5 /* Object.swift */; };
 		2590B1FA2510BB90003C0A03 /* VideoConference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2590B1F92510BB90003C0A03 /* VideoConference.swift */; };
 		2590B1FC2510C9F2003C0A03 /* VideoConferenceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2590B1FB2510C9F2003C0A03 /* VideoConferenceViewController.swift */; };
 		2592868A2473B1E00035EBA4 /* QuizReviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259286892473B1E00035EBA4 /* QuizReviewViewController.swift */; };
@@ -480,6 +481,7 @@
 		257BB696246AC22B00524D2C /* ExamQuestionsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExamQuestionsResponse.swift; sourceTree = "<group>"; };
 		257BB698246AC2ED00524D2C /* ExamQuestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExamQuestion.swift; sourceTree = "<group>"; };
 		258036A42743AA2400397639 /* DRMKeySessionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRMKeySessionDelegate.swift; sourceTree = "<group>"; };
+		2586782628ABB81700E149B5 /* Object.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Object.swift; sourceTree = "<group>"; };
 		2590B1F92510BB90003C0A03 /* VideoConference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoConference.swift; sourceTree = "<group>"; };
 		2590B1FB2510C9F2003C0A03 /* VideoConferenceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoConferenceViewController.swift; sourceTree = "<group>"; };
 		259286892473B1E00035EBA4 /* QuizReviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizReviewViewController.swift; sourceTree = "<group>"; };
@@ -1387,6 +1389,7 @@
 				25E435D4263ADBAA00243FD3 /* UserDefaults.swift */,
 				259ED9F8274E5B3100A87A71 /* Misc.swift */,
 				25520BBD2751093C001A58AB /* String.swift */,
+				2586782628ABB81700E149B5 /* Object.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1763,6 +1766,7 @@
 				2FDF9C5920B6F5240086245F /* BasePagedTableViewController.swift in Sources */,
 				2F515DF81FF3B8050005D8A5 /* KeyboardLayoutConstraint.swift in Sources */,
 				2FC0F2E81F863AE80092BFDC /* User.swift in Sources */,
+				2586782728ABB81700E149B5 /* Object.swift in Sources */,
 				257BB695246AB4C900524D2C /* QuizExamViewController.swift in Sources */,
 				2F70F4D71F9F1C3300D30755 /* BaseQuestionsListViewController.swift in Sources */,
 				2FC0F3101F863BA90092BFDC /* TestReportViewController.swift in Sources */,

--- a/ios-app/Extensions/Object.swift
+++ b/ios-app/Extensions/Object.swift
@@ -1,0 +1,58 @@
+//
+//  Object.swift
+//  ios-app
+
+import Realm
+import RealmSwift
+
+protocol DetachableObject: AnyObject {
+    func detached() -> Self
+}
+
+extension Object: DetachableObject {
+    func detached() -> Self {
+        let detached = type(of: self).init()
+        for property in objectSchema.properties {
+            guard let value = value(forKey: property.name) else {
+                continue
+            }
+            if let detachable = value as? DetachableObject {
+                detached.setValue(detachable.detached(), forKey: property.name)
+            } else { // Then it is a primitive
+                detached.setValue(value, forKey: property.name)
+            }
+        }
+        return detached
+    }
+}
+
+extension List: DetachableObject {
+    func detached() -> List<Element> {
+        let result = List<Element>()
+        forEach {
+            if let detachableObject = $0 as? DetachableObject,
+               let element = detachableObject.detached() as? Element {
+                result.append(element)
+            } else { // Then it is a primitive
+                result.append($0)
+            }
+        }
+        return result
+    }
+}
+
+extension Array {
+    func detached() -> Array<Element> {
+        var result = [Element]()
+        forEach {
+            if let detachableObject = $0 as? DetachableObject,
+               let element = detachableObject.detached() as? Element {
+                result.append(element)
+            } else {
+                result.append($0)
+            }
+        }
+        return result
+        
+    }
+}

--- a/ios-app/UI/ChaptersViewController.swift
+++ b/ios-app/UI/ChaptersViewController.swift
@@ -78,7 +78,7 @@ BaseDBViewController<Chapter> {
             filterQuery += String(format: " AND parentId=0")
         }
         
-        return DBManager<Chapter>().getItemsFromDB(filteredBy:filterQuery, byKeyPath: "order")
+        return DBManager<Chapter>().getItemsFromDB(filteredBy:filterQuery, byKeyPath: "order").detached()
     }
     
     func showItemsFromDB() {


### PR DESCRIPTION
- We display chapters from local first and then once chapters from remote are fetched, we will delete all local chapters and store all values from remote.
- Issue is if user click any chapter instantly when all chapters are deleted then app is crashing with exception `RLMException’, reason: ‘Object has been deleted or invalidated.`
- This is fixed by using detached or deep copied objects instead of directly using reference objects from realmdb
- [Ref](https://github.com/realm/realm-swift/issues/5578)