### PR TITLE
fix: Fix app crash on iOS 16 while playing video

### DIFF
--- a/ios-app/UI/VideoPlayerResourceLoaderDelegate.swift
+++ b/ios-app/UI/VideoPlayerResourceLoaderDelegate.swift
@@ -51,7 +51,7 @@ class VideoPlayerResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate
     }
     
     func setEncryptionKeyResponse(loadingRequest: AVAssetResourceLoadingRequest, data: Data) {
-        loadingRequest.contentInformationRequest?.contentType = AVStreamingKeyDeliveryPersistentContentKeyType
+        loadingRequest.contentInformationRequest?.contentType = AVStreamingKeyDeliveryContentKeyType
         loadingRequest.contentInformationRequest?.isByteRangeAccessSupported = true
         loadingRequest.contentInformationRequest?.contentLength = Int64(data.count)
         loadingRequest.dataRequest?.respond(with: data)

--- a/ios-app/UI/VideoPlayerResourceLoaderDelegate.swift
+++ b/ios-app/UI/VideoPlayerResourceLoaderDelegate.swift
@@ -51,10 +51,24 @@ class VideoPlayerResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate
     }
     
     func setEncryptionKeyResponse(loadingRequest: AVAssetResourceLoadingRequest, data: Data) {
-        loadingRequest.contentInformationRequest?.contentType = AVStreamingKeyDeliveryContentKeyType
+        loadingRequest.contentInformationRequest?.contentType = getContentType(contentInformationRequest: loadingRequest.contentInformationRequest)
         loadingRequest.contentInformationRequest?.isByteRangeAccessSupported = true
         loadingRequest.contentInformationRequest?.contentLength = Int64(data.count)
         loadingRequest.dataRequest?.respond(with: data)
         loadingRequest.finishLoading()
+    }
+    
+    func getContentType(contentInformationRequest: AVAssetResourceLoadingContentInformationRequest?) -> String{
+        var contentType = AVStreamingKeyDeliveryPersistentContentKeyType
+                 
+        if #available(iOS 11.2, *) {
+            if let allowedContentType = contentInformationRequest?.allowedContentTypes?.first{
+                if allowedContentType == AVStreamingKeyDeliveryContentKeyType{
+                    contentType = AVStreamingKeyDeliveryContentKeyType
+                }
+            }
+        }
+        
+        return contentType
     }
 }


### PR DESCRIPTION
- As per [documentation](https://developer.apple.com/documentation/avfoundation/avassetresourceloadingcontentinformationrequest/2936886-allowedcontenttypes) we must set content type that was present in `AVAssetResourceLoadingContentInformationRequest.allowedContentTypes` on AVAssetResourceLoadingContentInformationRequest while setting encryption key response, otherwise it will raise NSInternalInconsistencyException which cause app crash.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules