### PR TITLE
fix: Display video conference start time in local time format

### DIFF
--- a/ios-app/UI/VideoConferenceViewController.swift
+++ b/ios-app/UI/VideoConferenceViewController.swift
@@ -33,7 +33,7 @@ class VideoConferenceViewController: UIViewController {
         let videoConference = content.videoConference!
         duration.text = String(videoConference.duration)
         startDate.text = FormatDate.format(dateString: videoConference.start, requiredFormat: "dd-MM-yyyy")
-        startTime.text = FormatDate.format(dateString: videoConference.start, requiredFormat: "hh:mm a")
+        startTime.text = FormatDate.utcToLocalTime(dateStr: FormatDate.format(dateString: videoConference.start, requiredFormat: "hh:mm ss"))
     }
     
     @IBAction func openZoomMeeting(_ sender: Any?) {

--- a/ios-app/Utils/FormatDate.swift
+++ b/ios-app/Utils/FormatDate.swift
@@ -127,4 +127,17 @@ public class FormatDate {
         return "Just now"
     }
     
+    static func utcToLocalTime(dateStr: String) -> String? {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "H:mm:ss"
+        dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
+        
+        if let date = dateFormatter.date(from: dateStr) {
+            dateFormatter.timeZone = TimeZone.current
+            dateFormatter.dateFormat = "h:mm a"
+        
+            return dateFormatter.string(from: date)
+        }
+        return nil
+    }
 }


### PR DESCRIPTION
- The API sent UTC +0 and we displayed it as it is. As it leads to confusion among students, so display the start time in students' local time.

# Checklist:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules