### PR TITLE
fix: App crash while playing migrated video

### DIFF
--- a/ios-app/Utils/M3U8Handler.swift
+++ b/ios-app/Utils/M3U8Handler.swift
@@ -31,7 +31,7 @@ class M3U8Handler {
         /*
          We are changing schema of the key URL so that we can intercept it.
          */
-         var m3u8DataString = String(data: m3u8Data, encoding: .utf8)!
+        var m3u8DataString = String(data: m3u8Data, encoding: .utf8)!
         
         if m3u8DataString.contains("EXT-X-KEY:METHOD=AES-128") {
             let keyUrl = self.getKeyURL(m3u8DataString: m3u8DataString)

--- a/ios-app/Utils/M3U8Handler.swift
+++ b/ios-app/Utils/M3U8Handler.swift
@@ -56,7 +56,7 @@ class M3U8Handler {
             return String(keyURL)
         }
         
-        return "https://\(parentURL.host!)/\(parentURL.deletingLastPathComponent().relativeString)/\(keyURL)"
+        return "https://\(parentURL.host!)\(parentURL.deletingLastPathComponent().relativePath)/\(keyURL)"
     }
     
     private func modifyChunkedVideoURLs(url: URL, m3u8Data: Data) -> Data {


### PR DESCRIPTION
- Issue is migrated institute's video encryption key was stored in a bucket and the relative path was mentioned in the m3u8 file unlike the video hosted in Testpress m3u8 file will have an API URL as the key URL, so we Faked that URL with a schema called "fakekeyhttps" to set the authorization header while making API call for the key.
- That faking wasn't done for migrated m3u8 file key URL so the app getting crashed while playing the video which was fixed in this commit.


# Checklist:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation