### PR TITLE
fix: App crash while accessing empty course

### DIFF
--- a/ios-app/Core/Constants.swift
+++ b/ios-app/Core/Constants.swift
@@ -26,7 +26,7 @@
 import Foundation
 
 struct Constants {
-    static let BASE_URL = "https://fortuneiasacademy.testpress.in";
+    static let BASE_URL = "https://lmsdemo.testpress.in";
     static let APP_APPLE_ID = "1434052944"
     
     static let APP_SHARE_MESSAGE = "Good app to prepare for online exams. Get it at http://itunes.apple.com/app/id" + APP_APPLE_ID

--- a/ios-app/Core/Constants.swift
+++ b/ios-app/Core/Constants.swift
@@ -26,7 +26,7 @@
 import Foundation
 
 struct Constants {
-    static let BASE_URL = "https://lmsdemo.testpress.in";
+    static let BASE_URL = "https://fortuneiasacademy.testpress.in";
     static let APP_APPLE_ID = "1434052944"
     
     static let APP_SHARE_MESSAGE = "Good app to prepare for online exams. Get it at http://itunes.apple.com/app/id" + APP_APPLE_ID

--- a/ios-app/Core/Strings.swift
+++ b/ios-app/Core/Strings.swift
@@ -44,6 +44,7 @@ struct Strings {
     static let USERNAME_PASSWORD_NOT_MATCHED = "Username & Password didn't match. Please try again."
     
     static let NO_ITEMS_EXIST = "No items exist"
+    static let NO_CONTENTS_EXIST = "Empty Course"
     static let NO_EXAMS = "Learning can't wait"
     static let NO_AVAILABLE_EXAM = "Looks like you don't have any active exams. Contact administrator for more details."
     static let NO_UPCOMING_EXAM = "Looks like you don't have any upcoming exams."
@@ -53,7 +54,7 @@ struct Strings {
     
     static let NO_COURSES = "Learning can't wait"
     static let NO_COURSE_DESCRIPTION = "Looks like you don’t have any active courses. Kindly contact admin."
-    static let NO_CHAPTER_DESCRIPTION = "Looks like chapters not available. Check back later."
+    static let NO_CHAPTER_DESCRIPTION = "The course doesn't have any chapters or contents"
     static let NO_CONTENT_DESCRIPTION = "Looks like contents not available. Check back later."
     
     static let NO_POSTS = "Breaking news!"

--- a/ios-app/UI/ChaptersViewController.swift
+++ b/ios-app/UI/ChaptersViewController.swift
@@ -150,7 +150,7 @@ BaseDBViewController<Chapter> {
     }
     
     func setEmptyText() {
-        emptyView.setValues(image: Images.LearnFlatIcon.image, title: Strings.NO_ITEMS_EXIST,
+        emptyView.setValues(image: Images.LearnFlatIcon.image, title: Strings.NO_CONTENTS_EXIST,
                             description: Strings.NO_CHAPTER_DESCRIPTION)
     }
     

--- a/ios-app/UI/CourseTableViewCell.swift
+++ b/ios-app/UI/CourseTableViewCell.swift
@@ -85,25 +85,13 @@ class CourseTableViewCell: UITableViewCell {
             webViewController.title = course.title
             parentViewController.present(webViewController, animated: true, completion: nil)
         } else {
-            if course.chaptersCount > 0 {
-                let chaptersViewController = storyboard.instantiateViewController(withIdentifier:
-                    Constants.CHAPTERS_VIEW_CONTROLLER) as! ChaptersViewController
-                
-                chaptersViewController.courseId = course.id
-                chaptersViewController.coursesUrl = course.url
-                chaptersViewController.title = course.title
-                viewController = chaptersViewController
-            } else {
-                let contentsNavigationController = storyboard.instantiateViewController(withIdentifier:
-                    Constants.CONTENTS_LIST_NAVIGATION_CONTROLLER) as! UINavigationController
-                
-                let contentViewController = contentsNavigationController.viewControllers.first
-                    as! ContentsTableViewController
-                
-                contentViewController.contentsUrl = course.contentsUrl
-                contentViewController.title = course.title
-                viewController = contentsNavigationController
-            }
+            let chaptersViewController = storyboard.instantiateViewController(withIdentifier:
+                Constants.CHAPTERS_VIEW_CONTROLLER) as! ChaptersViewController
+
+            chaptersViewController.courseId = course.id
+            chaptersViewController.coursesUrl = course.url
+            chaptersViewController.title = course.title
+            viewController = chaptersViewController
             parentViewController.present(viewController, animated: true, completion: nil)
         }
     }


### PR DESCRIPTION
- Currently, when the user clicks on the course we redirected the user to the contents table view if the courses don't have any chapters, which causes the app crash because in the ContentTableViewController we showed contents filtered by chapter id.
- This is fixed by showing the chapters table view where we set an empty view if the course doesn't have any chapter.


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules