### PR TITLE
fix: App crash logs not tracked in Sentry

### DIFF
--- a/ios-app/AppDelegate.swift
+++ b/ios-app/AppDelegate.swift
@@ -116,7 +116,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             ]
         }
         
-        let config = Realm.Configuration(schemaVersion: 23)
+        let config = Realm.Configuration(schemaVersion: 24)
         Realm.Configuration.defaultConfiguration = config
         let viewController:UIViewController
         

--- a/ios-app/AppDelegate.swift
+++ b/ios-app/AppDelegate.swift
@@ -110,13 +110,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             userDefaults.synchronize() // Forces the app to update UserDefaults
         }
         
-        do {
-            Client.shared = try Client(dsn: "https://15420a637fb7479a832b721fb7cc0ceb@sentry.testpress.in/4")
-            try Client.shared?.startCrashHandler()
-        } catch let error {
-            print("\(error)")
-        }
-        
         if (KeychainTokenItem.isExist()) {
             Client.shared?.extra = [
                 "username": KeychainTokenItem.getAccount()
@@ -133,6 +126,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             UIUtils.fetchInstituteSettings(completion:{ _,_  in })
             viewController = UIUtils.getLoginOrTabViewController()
         }
+        
+        if (InstituteSettings.isAvailable()){
+            let instituteSettings = DBManager<InstituteSettings>().getResultsFromDB()[0]
+            do {
+                Client.shared = try Client(dsn: instituteSettings.sentryDSN)
+                try Client.shared?.startCrashHandler()
+            } catch let error {
+                print("\(error)")
+            }
+            
+        }
+        
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.rootViewController = viewController
         window?.makeKeyAndVisible()

--- a/ios-app/Model/InstituteSettings.swift
+++ b/ios-app/Model/InstituteSettings.swift
@@ -62,6 +62,7 @@ class InstituteSettings: DBModel {
     @objc dynamic var customRegistrationEnabled: Bool = false
     @objc dynamic var fairplayCertificateUrl: String = ""
     @objc dynamic var isHelpdeskEnabled: Bool = false
+    @objc dynamic var sentryDSN: String = ""
 
     public override func mapping(map: Map) {
         verificationMethod <- map["verification_method"]
@@ -96,6 +97,7 @@ class InstituteSettings: DBModel {
         customRegistrationEnabled <- map["custom_registration_enabled"]
         fairplayCertificateUrl <- map["fairplay_certificate_url"]
         isHelpdeskEnabled <- map["is_helpdesk_enabled"]
+        sentryDSN <- map["ios_sentry_dns"]
     }
     
     override public static func primaryKey() -> String? {


### PR DESCRIPTION
- We used an invalid Sentry DSN while initializing the Sentry that's why app crash logs were not tracked, this is fixed by using DSN from the institute settings.