### PR TITLE
chore: Remove zoom dead code

### DIFF
--- a/ios-app/AppDelegate.swift
+++ b/ios-app/AppDelegate.swift
@@ -141,7 +141,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.rootViewController = viewController
         window?.makeKeyAndVisible()
-        Zoom.enableFullScreenForMeetingWaitView()
         return true
     }
     

--- a/ios-app/UI/ZoomMeetViewController.swift
+++ b/ios-app/UI/ZoomMeetViewController.swift
@@ -189,20 +189,3 @@ class ZoomMeetViewController: UIViewController, MobileRTCAuthDelegate, MobileRTC
         meetingService?.delegate = nil
     }
 }
-
-class Zoom {
-    static func enableFullScreenForMeetingWaitView() {
-        if let klass = NSClassFromString("ZPMeetingWaitViewController") {
-            guard let original = class_getInstanceMethod(klass, #selector(getter: UIViewController.modalPresentationStyle)), let replacement = class_getInstanceMethod(self, #selector(getter:Zoom.modalPresentationStyle))
-                else { return }
-            method_exchangeImplementations(original, replacement)
-        } else {
-            debugPrint("No Class named `ZPMeetingWaitViewController`")
-        }
-    }
-    
-    @objc var modalPresentationStyle: UIModalPresentationStyle {
-        .fullScreen
-    }
-}
-


### PR DESCRIPTION
- Since we have updated zoom, by default full-screen is enabled for the waiting room, we don't need to do it separately and this code is causing some degradation in the meeting screen.