### PR TITLE
fix: Video not playing if its URL contains non-ascii characters

### DIFF
--- a/ios-app/Model/Video.swift
+++ b/ios-app/Model/Video.swift
@@ -37,14 +37,13 @@ class Video: DBModel {
     var streams = List<Stream>()
     
     func getHlsUrl() -> String {
+        var url = self.url
         if let hlsURL = self.streams.first(where: {$0.hlsUrl.isNotEmpty}) {
-            return hlsURL.hlsUrl
+            url = hlsURL.hlsUrl
+        } else if let hls = self.streams.first(where: {$0.format == "HLS"}) {
+            url = hls.url
         }
-        
-        if let hls = self.streams.first(where: {$0.format == "HLS"}) {
-            return hls.url
-        }
-        return self.url
+        return url.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? url
     }
     
     var isDRMProtected: Bool {


### PR DESCRIPTION
- `URL` initializer will return nil if the given URL string contains non-ASCII this causes the app crash while playing the videos.
- This is fixed by encoding the URL string before creating a `URL` object from it.
- StackOverFlow [thread](https://stackoverflow.com/questions/49575034/url-in-diffrent-language-how-to-convert-a-url-in-swift).