### PR TITLE
Update IosPDFReader

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,6 +1,6 @@
 github "airbnb/lottie-ios" "2.5.0"
 github "Alamofire/Alamofire" "5.0.2"
-github "Alua-Kinzhebayeva/iOS-PDF-Reader" "2.5.1"
+github "testpress/iOS-PDF-Reader" "2.5.2"
 github "testpress/DropDown-Swift" "2.3.14"
 github "danielgindi/Charts" "v4.1.0"
 github "AtomicSLLC/SlideMenuControllerSwift" "5.0.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,7 +1,7 @@
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" "6.8.0"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseMessagingBinary.json" "6.8.0"
 github "Alamofire/Alamofire" "5.0.2"
-github "Alua-Kinzhebayeva/iOS-PDF-Reader" "2.5.1"
+github "testpress/iOS-PDF-Reader" "2.5.2"
 github "testpress/DropDown-Swift" "2.3.14"
 github "AtomicSLLC/SlideMenuControllerSwift" "5.0.0"
 github "Hearst-DD/ObjectMapper" "4.2.0"

--- a/ios-app.xcodeproj/project.pbxproj
+++ b/ios-app.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		25489AA12A0BAD81009619FD /* MarqueeLabel.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25489AA02A0BAD81009619FD /* MarqueeLabel.xcframework */; };
 		25489AA32A0BB309009619FD /* DropDown.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25489AA22A0BB309009619FD /* DropDown.xcframework */; };
 		25489AA52A0BB621009619FD /* ObjectMapper.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25489AA42A0BB621009619FD /* ObjectMapper.xcframework */; };
+		25489AA72A0BBC44009619FD /* PDFReader.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25489AA62A0BBC44009619FD /* PDFReader.xcframework */; };
 		2548C4922476CFAC00F90D09 /* BaseDBTableViewControllerV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2548C4912476CFAC00F90D09 /* BaseDBTableViewControllerV2.swift */; };
 		254E69C421DCF199009A4E61 /* Testpress_iOS_AppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254E69C321DCF199009A4E61 /* Testpress_iOS_AppUITests.swift */; };
 		25520BB62750FAC0001A58AB /* ForumFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25520BB52750FAC0001A58AB /* ForumFilterViewController.swift */; };
@@ -198,7 +199,6 @@
 		2F515DFC1FF4EF9C0005D8A5 /* FileDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F515DFB1FF4EF9C0005D8A5 /* FileDetails.swift */; };
 		2F515DFE1FF517160005D8A5 /* Permissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F515DFD1FF517160005D8A5 /* Permissions.swift */; };
 		2F515E021FF61A550005D8A5 /* ImageUploadHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F515E011FF61A550005D8A5 /* ImageUploadHelper.swift */; };
-		2F52CB7B20173BA300592CD8 /* PDFReader.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F52CB7A20173BA300592CD8 /* PDFReader.framework */; };
 		2F56B7351FDD252E00E2B240 /* GraphAxisLabelFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F56B7341FDD252E00E2B240 /* GraphAxisLabelFormatter.swift */; };
 		2F56B7371FDD2F0100E2B240 /* GraphAxisPercentValueFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F56B7361FDD2F0100E2B240 /* GraphAxisPercentValueFormatter.swift */; };
 		2F56B7391FDD6B5700E2B240 /* IndividualSubjectAnalyticsGraphCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F56B7381FDD6B5700E2B240 /* IndividualSubjectAnalyticsGraphCell.swift */; };
@@ -442,6 +442,7 @@
 		25489AA02A0BAD81009619FD /* MarqueeLabel.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = MarqueeLabel.xcframework; path = Carthage/Build/MarqueeLabel.xcframework; sourceTree = "<group>"; };
 		25489AA22A0BB309009619FD /* DropDown.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DropDown.xcframework; path = Carthage/Build/DropDown.xcframework; sourceTree = "<group>"; };
 		25489AA42A0BB621009619FD /* ObjectMapper.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = ObjectMapper.xcframework; path = Carthage/Build/ObjectMapper.xcframework; sourceTree = "<group>"; };
+		25489AA62A0BBC44009619FD /* PDFReader.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PDFReader.xcframework; path = Carthage/Build/PDFReader.xcframework; sourceTree = "<group>"; };
 		2548C4912476CFAC00F90D09 /* BaseDBTableViewControllerV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseDBTableViewControllerV2.swift; sourceTree = "<group>"; };
 		254E69C121DCF199009A4E61 /* Testpress iOS AppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Testpress iOS AppUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		254E69C321DCF199009A4E61 /* Testpress_iOS_AppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Testpress_iOS_AppUITests.swift; sourceTree = "<group>"; };
@@ -823,6 +824,7 @@
 				259932872A0A64F800866CA8 /* RealmSwift.xcframework in Frameworks */,
 				2570A25121CA0D770097C6FE /* FirebaseMessaging.framework in Frameworks */,
 				259932752A0A4BB800866CA8 /* Lottie.xcframework in Frameworks */,
+				25489AA72A0BBC44009619FD /* PDFReader.xcframework in Frameworks */,
 				259932732A0A4B9A00866CA8 /* Former.xcframework in Frameworks */,
 				2599326F2A0A3F4600866CA8 /* FBSDKCoreKit_Basics.xcframework in Frameworks */,
 				2599326B2A0A3C2700866CA8 /* FBSDKCoreKit.xcframework in Frameworks */,
@@ -832,7 +834,6 @@
 				2599327F2A0A505300866CA8 /* Kingfisher.xcframework in Frameworks */,
 				25489A9F2A0B9EEA009619FD /* TTGSnackbar.xcframework in Frameworks */,
 				259932692A0A2FB600866CA8 /* XLPagerTabStrip.xcframework in Frameworks */,
-				2F52CB7B20173BA300592CD8 /* PDFReader.framework in Frameworks */,
 				2F763D031FBD83340033D495 /* SlideMenuControllerSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1015,6 +1016,7 @@
 		2FBEDB781E82BBD0000CF05C /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				25489AA62A0BBC44009619FD /* PDFReader.xcframework */,
 				25489AA42A0BB621009619FD /* ObjectMapper.xcframework */,
 				25489AA22A0BB309009619FD /* DropDown.xcframework */,
 				25489AA02A0BAD81009619FD /* MarqueeLabel.xcframework */,
@@ -1654,7 +1656,6 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/iOS/SlideMenuControllerSwift.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/PDFReader.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/IGListDiffKit.framework",
 			);
 			name = "Run Script";


### PR DESCRIPTION
- IosPDFReader was not being maintained for last 3 years. So it is not supported in XCode 14.
- To support that package, it has to change minimum deployment target to 11
- Forked IosPDFReader to our account(https://github.com/testpress/iOS-PDF-Reader) and changed minimum deployment target to 11