### PR TITLE
Fix DRM videos not playing bug

### DIFF
--- a/ios-app/UI/DRMKeySessionDelegate.swift
+++ b/ios-app/UI/DRMKeySessionDelegate.swift
@@ -14,9 +14,10 @@ class DRMKeySessionDelegate: NSObject, AVContentKeySessionDelegate {
     @available(iOS 10.3, *)
     func contentKeySession(_ session: AVContentKeySession, didProvide keyRequest: AVContentKeyRequest) {
         
-        guard let contentId = keyRequest.identifier as? String else {
-            keyRequest.processContentKeyResponseError(DRMError.noContentId)
-            return
+        guard let contentKeyIdentifier = keyRequest.identifier as? NSURL, let contentId = contentKeyIdentifier.host
+            else {
+                print("Failed to retrieve the assetID from the keyRequest!")
+                return
         }
         
         fetchDRMKey(keyRequest, contentId)
@@ -95,7 +96,6 @@ class DRMKeySessionDelegate: NSObject, AVContentKeySessionDelegate {
         var request = URLRequest(url: URL(string: licenseURL)!)
         request.httpMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.addValue("application/octet-stream", forHTTPHeaderField: "Accept")
         do {
             try request.httpBody = try JSONSerialization.data(withJSONObject: parameters, options: .prettyPrinted)
         } catch {}


### PR DESCRIPTION
- There were 2 bugs in the code
- One is contentID was not properly parsed. We are trying to type case content identifier("skd://<contend_id>") as string. But ideally it should be casted as url and then content id should be extracted from it.
- Another bug is DRM API failure. This is because we are adding Accept header which the server is rejecting.