### PR TITLE
fix: App crash on uploading image in comment on post 

### DIFF
--- a/ios-app/Utils/ImagePicker.swift
+++ b/ios-app/Utils/ImagePicker.swift
@@ -64,10 +64,11 @@ class ImagePicker: NSObject {
             title: Strings.CAMERA,
             style: .default,
             handler: { (alert:UIAlertAction!) -> Void in
-                checkCameraAuthorizationStatus(viewController: viewController, completion: {
-                    authorized in
-                    if authorized {
-                        self.pickImage(sourceType: .camera)
+                checkCameraAuthorizationStatus(viewController: viewController, completion: { authorized in
+                    DispatchQueue.main.async {
+                        if authorized {
+                            self.pickImage(sourceType: .camera)
+                        }
                     }
                 })
                 
@@ -76,10 +77,11 @@ class ImagePicker: NSObject {
             title: Strings.PHOTO_LIBRARY,
             style: .default,
             handler: { (alert:UIAlertAction!) -> Void in
-                checkPhotoLibraryAuthorizationStatus(viewController: viewController, completion: {
-                    authorized in
-                    if authorized {
-                        self.pickImage(sourceType: .photoLibrary)
+                checkPhotoLibraryAuthorizationStatus(viewController: viewController, completion: { authorized in
+                    DispatchQueue.main.async {
+                        if authorized {
+                            self.pickImage(sourceType: .photoLibrary)
+                        }
                     }
                 })
         }))


### PR DESCRIPTION
- Previously, when a user commented on a post, we would display an image picker dialog. If the user had not granted permission, we would request permission. This process would run on a background thread. If the user granted authorization, we needed to launch the camera to capture an image or show the selected file to choose an image. However, launching the camera was not possible from a background thread. In this commit, we have addressed this issue by ensuring that the camera is launched and the file selection for choosing an image is done on the main thread.