### PR TITLE
fix: Screen rotation not working on iOS versions 16 and higher.

### DIFF
--- a/ios-app.xcodeproj/project.pbxproj
+++ b/ios-app.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		036654CD2A3D98930005BDDF /* UIInterfaceOrientationMask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036654CC2A3D98930005BDDF /* UIInterfaceOrientationMask.swift */; };
 		1825F5FD212E8BF900AC25E5 /* AttemptSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1825F5FC212E8BF900AC25E5 /* AttemptSection.swift */; };
 		1825F5FF212E920C00AC25E5 /* PlainDropDown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1825F5FE212E920C00AC25E5 /* PlainDropDown.swift */; };
 		18F25D27212FDB7000097425 /* LockableSectionDropDownCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 18F25D26212FDB7000097425 /* LockableSectionDropDownCell.xib */; };
@@ -449,6 +450,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		036654CC2A3D98930005BDDF /* UIInterfaceOrientationMask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIInterfaceOrientationMask.swift; sourceTree = "<group>"; };
 		1825F5FC212E8BF900AC25E5 /* AttemptSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttemptSection.swift; sourceTree = "<group>"; };
 		1825F5FE212E920C00AC25E5 /* PlainDropDown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainDropDown.swift; sourceTree = "<group>"; };
 		18F25D26212FDB7000097425 /* LockableSectionDropDownCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LockableSectionDropDownCell.xib; sourceTree = "<group>"; };
@@ -1407,6 +1409,7 @@
 				259ED9F8274E5B3100A87A71 /* Misc.swift */,
 				25520BBD2751093C001A58AB /* String.swift */,
 				2586782628ABB81700E149B5 /* Object.swift */,
+				036654CC2A3D98930005BDDF /* UIInterfaceOrientationMask.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1832,6 +1835,7 @@
 				8C2E7B602397B56600BA2F41 /* VideoPlayerControlsView.swift in Sources */,
 				2F17C1FE20C965B300606D5C /* BookmarkFoldersDropDown.swift in Sources */,
 				2FC0F2E41F863ADC0092BFDC /* TPApiResponse.swift in Sources */,
+				036654CD2A3D98930005BDDF /* UIInterfaceOrientationMask.swift in Sources */,
 				25DFC1682609B00700E06BA7 /* StringArrayTransform.swift in Sources */,
 				8C205A082323918700596E66 /* LoginActivityCell.swift in Sources */,
 				2F48C8111FD28E7A009C686C /* PostPager.swift in Sources */,

--- a/ios-app/Extensions/UIInterfaceOrientationMask.swift
+++ b/ios-app/Extensions/UIInterfaceOrientationMask.swift
@@ -1,0 +1,24 @@
+//
+//  UIInterfaceOrientationMask.swift
+//  ios-app
+//
+//  Created by Testpress on 17/06/23.
+//  Copyright © 2023 Testpress. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+
+extension UIInterfaceOrientationMask {
+    var toUIInterfaceOrientation: UIInterfaceOrientation {
+        switch self {
+        case .portrait:
+            return UIInterfaceOrientation.portrait
+        case .landscapeRight:
+            return UIInterfaceOrientation.landscapeRight
+        default:
+            return UIInterfaceOrientation.unknown
+        }
+    }
+}

--- a/ios-app/Extensions/UIViewController.swift
+++ b/ios-app/Extensions/UIViewController.swift
@@ -46,4 +46,28 @@ extension UIViewController {
         view.removeFromSuperview()
         removeFromParent()
     }
+    
+    func getCurrentOrientation() -> UIInterfaceOrientation {
+        if #available(iOS 16.0, *) {
+            if let orientation = UIApplication.shared.windows.first?.windowScene?.interfaceOrientation {
+                return orientation
+            }
+        } else {
+            let deviceOrientation = UIDevice.current.orientation
+            switch deviceOrientation {
+            case .portrait:
+                return .portrait
+            case .portraitUpsideDown:
+                return .portraitUpsideDown
+            case .landscapeLeft:
+                return .landscapeRight
+            case .landscapeRight:
+                return .landscapeLeft
+            default:
+                break
+            }
+        }
+        
+        return .unknown
+    }
 }

--- a/ios-app/UI/VideoContentViewController.swift
+++ b/ios-app/UI/VideoContentViewController.swift
@@ -272,7 +272,7 @@ class VideoContentViewController: UIViewController,UITableViewDelegate, UITableV
         UIApplication.shared.keyWindow?.removeVideoPlayerView()
         view.addSubview(videoPlayerView)
         
-        if (self.getCurrentOrientation().isLandscape) {
+        if (getCurrentOrientation().isLandscape) {
             playerFrame = UIScreen.main.bounds
             UIApplication.shared.keyWindow!.addSubview(videoPlayerView)
         }
@@ -281,32 +281,7 @@ class VideoContentViewController: UIViewController,UITableViewDelegate, UITableV
         videoPlayerView.layoutIfNeeded()
         videoPlayerView.playerLayer?.frame = playerFrame
     }
-    
-    func getCurrentOrientation() -> UIInterfaceOrientation {
-        if #available(iOS 16.0, *) {
-            if let orientation = UIApplication.shared.windows.first?.windowScene?.interfaceOrientation {
-                return orientation
-            }
-        } else {
-            let deviceOrientation = UIDevice.current.orientation
-            switch deviceOrientation {
-            case .portrait:
-                return .portrait
-            case .portraitUpsideDown:
-                return .portraitUpsideDown
-            case .landscapeLeft:
-                return .landscapeRight
-            case .landscapeRight:
-                return .landscapeLeft
-            default:
-                break
-            }
-        }
-        
-        return .unknown
-    }
-    
-    
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         addObservers()
@@ -468,8 +443,13 @@ class VideoContentViewController: UIViewController,UITableViewDelegate, UITableV
 }
 
 extension VideoContentViewController: VideoPlayerDelegate {
+    
+    func showOptionsMenu() {
+        displayOptions()
+    }
+    
     func toggleFullScreen() {
-        if self.getCurrentOrientation().isLandscape {
+        if getCurrentOrientation().isLandscape {
             changeDeviceOrientation(orientation: .portrait)
         } else {
             changeDeviceOrientation(orientation: .landscapeRight)
@@ -478,16 +458,12 @@ extension VideoContentViewController: VideoPlayerDelegate {
     }
     
     func changeDeviceOrientation(orientation: UIInterfaceOrientationMask) {
-            if #available(iOS 16.0, *) {
-                let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-                windowScene?.requestGeometryUpdate(.iOS(interfaceOrientations: orientation))
-            } else {
-                UIDevice.current.setValue(orientation.toUIInterfaceOrientation.rawValue, forKey: "orientation")
-            }
+        if #available(iOS 16.0, *) {
+            let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+            windowScene?.requestGeometryUpdate(.iOS(interfaceOrientations: orientation))
+        } else {
+            UIDevice.current.setValue(orientation.toUIInterfaceOrientation.rawValue, forKey: "orientation")
         }
-    
-    func showOptionsMenu() {
-        displayOptions()
     }
 }
 

--- a/ios-app/UI/VideoContentViewController.swift
+++ b/ios-app/UI/VideoContentViewController.swift
@@ -272,7 +272,7 @@ class VideoContentViewController: UIViewController,UITableViewDelegate, UITableV
         UIApplication.shared.keyWindow?.removeVideoPlayerView()
         view.addSubview(videoPlayerView)
         
-        if (UIDevice.current.orientation.isLandscape) {
+        if (self.getCurrentOrientation().isLandscape) {
             playerFrame = UIScreen.main.bounds
             UIApplication.shared.keyWindow!.addSubview(videoPlayerView)
         }
@@ -280,6 +280,30 @@ class VideoContentViewController: UIViewController,UITableViewDelegate, UITableV
         customView.frame = videoPlayerView.frame
         videoPlayerView.layoutIfNeeded()
         videoPlayerView.playerLayer?.frame = playerFrame
+    }
+    
+    func getCurrentOrientation() -> UIInterfaceOrientation {
+        if #available(iOS 16.0, *) {
+            if let orientation = UIApplication.shared.windows.first?.windowScene?.interfaceOrientation {
+                return orientation
+            }
+        } else {
+            let deviceOrientation = UIDevice.current.orientation
+            switch deviceOrientation {
+            case .portrait:
+                return .portrait
+            case .portraitUpsideDown:
+                return .portraitUpsideDown
+            case .landscapeLeft:
+                return .landscapeRight
+            case .landscapeRight:
+                return .landscapeLeft
+            default:
+                break
+            }
+        }
+        
+        return .unknown
     }
     
     
@@ -444,11 +468,28 @@ class VideoContentViewController: UIViewController,UITableViewDelegate, UITableV
 }
 
 extension VideoContentViewController: VideoPlayerDelegate {
+    func toggleFullScreen() {
+        if self.getCurrentOrientation().isLandscape {
+            changeDeviceOrientation(orientation: .portrait)
+        } else {
+            changeDeviceOrientation(orientation: .landscapeRight)
+        }
+                                 
+    }
+    
+    func changeDeviceOrientation(orientation: UIInterfaceOrientationMask) {
+            if #available(iOS 16.0, *) {
+                let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+                windowScene?.requestGeometryUpdate(.iOS(interfaceOrientations: orientation))
+            } else {
+                UIDevice.current.setValue(orientation.toUIInterfaceOrientation.rawValue, forKey: "orientation")
+            }
+        }
+    
     func showOptionsMenu() {
         displayOptions()
     }
 }
-
 
 extension UIWindow {
     func removeVideoPlayerView() {

--- a/ios-app/Views/VideoPlayerView.swift
+++ b/ios-app/Views/VideoPlayerView.swift
@@ -294,12 +294,7 @@ extension VideoPlayerView: PlayerControlDelegate {
     }
     
     func fullScreen() {
-        var value = UIInterfaceOrientation.landscapeRight.rawValue
-
-        if UIDevice.current.orientation.isLandscape {
-            value = UIInterfaceOrientation.portrait.rawValue
-        }
-        UIDevice.current.setValue(value, forKey: "orientation")
+        playerDelegate?.toggleFullScreen()
     }
     
     func isPlaying() -> Bool {
@@ -309,5 +304,6 @@ extension VideoPlayerView: PlayerControlDelegate {
 
 protocol VideoPlayerDelegate: class {
     func showOptionsMenu()
+    func toggleFullScreen()
 }
 


### PR DESCRIPTION
- The usage of UIDevice.current.setValue() specifically for screen rotation has been deprecated starting from iOS 16. Instead, for iOS 16 and newer versions, we now utilize requestGeometryUpdate() to achieve the same functionality. However, for iOS versions earlier than 16, we continue to rely on the old method setValue() for screen rotation.
