### PR TITLE
fix: Replace Button to the respective layout

### DIFF
--- a/ios-app/Base.lproj/ExamReview.storyboard
+++ b/ios-app/Base.lproj/ExamReview.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_0" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -27,7 +25,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0Pg-wp-aPm">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                                <rect key="frame" x="0.0" y="20" width="320" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="lqf-5e-oVb"/>
                                 </constraints>
@@ -43,7 +41,7 @@
                                 </items>
                             </navigationBar>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Vxf-PL-fVq">
-                                <rect key="frame" x="0.0" y="64" width="320" height="588"/>
+                                <rect key="frame" x="0.0" y="64" width="320" height="603"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NDB-Vf-fVH">
                                         <rect key="frame" x="0.0" y="0.0" width="320" height="700"/>
@@ -383,7 +381,7 @@
                                                                         <rect key="frame" x="0.0" y="0.0" width="160" height="52"/>
                                                                         <subviews>
                                                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="XoJ-ex-Mkp">
-                                                                                <rect key="frame" x="5" y="0.0" width="150" height="52"/>
+                                                                                <rect key="frame" x="5.5" y="0.0" width="149.5" height="52"/>
                                                                                 <subviews>
                                                                                     <view contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="vPG-J6-hYi">
                                                                                         <rect key="frame" x="0.0" y="0.0" width="52" height="52"/>
@@ -422,10 +420,10 @@
                                                                                         </userDefinedRuntimeAttributes>
                                                                                     </view>
                                                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="8GO-NR-Xve">
-                                                                                        <rect key="frame" x="62" y="7" width="88" height="38.5"/>
+                                                                                        <rect key="frame" x="62" y="7" width="87.5" height="38.5"/>
                                                                                         <subviews>
                                                                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="lastBaseline" translatesAutoresizingMaskIntoConstraints="NO" id="3wT-si-wRg">
-                                                                                                <rect key="frame" x="0.0" y="0.0" width="88" height="21.5"/>
+                                                                                                <rect key="frame" x="0.0" y="0.0" width="87.5" height="21.5"/>
                                                                                                 <subviews>
                                                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JsH-iR-mWm">
                                                                                                         <rect key="frame" x="0.0" y="0.0" width="47.5" height="21.5"/>
@@ -434,13 +432,13 @@
                                                                                                         <nil key="highlightedColor"/>
                                                                                                     </label>
                                                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="/" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J5c-qo-KKe">
-                                                                                                        <rect key="frame" x="47.5" y="3.5" width="5" height="17"/>
+                                                                                                        <rect key="frame" x="47.5" y="3.5" width="4.5" height="17"/>
                                                                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                                                         <color key="textColor" red="0.46666666670000001" green="0.46666666670000001" blue="0.46666666670000001" alpha="1" colorSpace="calibratedRGB"/>
                                                                                                         <nil key="highlightedColor"/>
                                                                                                     </label>
                                                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rkp-Bi-dqb">
-                                                                                                        <rect key="frame" x="52.5" y="4" width="35.5" height="17"/>
+                                                                                                        <rect key="frame" x="52" y="4" width="35.5" height="17"/>
                                                                                                         <fontDescription key="fontDescription" name="Rubik-Regular" family="Rubik" pointSize="14"/>
                                                                                                         <color key="textColor" red="0.46666666670000001" green="0.46666666670000001" blue="0.46666666670000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                                                         <nil key="highlightedColor"/>
@@ -1025,7 +1023,7 @@
                                 </constraints>
                             </scrollView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="D74-Wv-07Z">
-                                <rect key="frame" x="0.0" y="644" width="320" height="156"/>
+                                <rect key="frame" x="0.0" y="659" width="320" height="141"/>
                                 <subviews>
                                     <view alpha="0.10000000000000001" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Cw2-cS-8Rg">
                                         <rect key="frame" x="0.0" y="0.0" width="320" height="8"/>
@@ -1035,12 +1033,12 @@
                                         </constraints>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="rEr-EX-qb1">
-                                        <rect key="frame" x="15" y="18" width="290" height="128"/>
+                                        <rect key="frame" x="15" y="18" width="290" height="113"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="oHa-OG-knM">
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="7XX-ai-BYG">
                                                 <rect key="frame" x="0.0" y="0.0" width="290" height="30"/>
                                                 <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KCg-y8-gbZ">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KCg-y8-gbZ">
                                                         <rect key="frame" x="0.0" y="0.0" width="137.5" height="30"/>
                                                         <color key="backgroundColor" red="0.0" green="0.80000000000000004" blue="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <fontDescription key="fontDescription" name="Rubik-Medium" family="Rubik" pointSize="12"/>
@@ -1056,32 +1054,8 @@
                                                             <action selector="showSubjectAnalytics:" destination="3z8-h4-idf" eventType="touchUpInside" id="ggL-mn-f06"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Y79-Ub-iWU">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Uox-a4-XPT">
                                                         <rect key="frame" x="152.5" y="0.0" width="137.5" height="30"/>
-                                                        <color key="backgroundColor" red="0.0" green="0.80000000000000004" blue="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        <fontDescription key="fontDescription" name="Rubik-Medium" family="Rubik" pointSize="12"/>
-                                                        <state key="normal" title="SOLUTIONS">
-                                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                                        </state>
-                                                        <userDefinedRuntimeAttributes>
-                                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                                <integer key="value" value="15"/>
-                                                            </userDefinedRuntimeAttribute>
-                                                        </userDefinedRuntimeAttributes>
-                                                        <connections>
-                                                            <action selector="showSolutions:" destination="3z8-h4-idf" eventType="touchUpInside" id="oZd-gC-Pm1"/>
-                                                        </connections>
-                                                    </button>
-                                                </subviews>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="30" id="NKz-Vw-kgb"/>
-                                                </constraints>
-                                            </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="7XX-ai-BYG">
-                                                <rect key="frame" x="0.0" y="40" width="290" height="30"/>
-                                                <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Uox-a4-XPT">
-                                                        <rect key="frame" x="0.0" y="0.0" width="137.5" height="30"/>
                                                         <color key="backgroundColor" red="0.0" green="0.80000000000000004" blue="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <fontDescription key="fontDescription" name="Rubik-Medium" family="Rubik" pointSize="12"/>
                                                         <state key="normal" title="TIME ANALYTICS">
@@ -1096,20 +1070,44 @@
                                                             <action selector="showTimeAnalytics:" destination="3z8-h4-idf" eventType="touchUpInside" id="D2f-cS-fVu"/>
                                                         </connections>
                                                     </button>
+                                                </subviews>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="30" id="eKV-NR-ww8"/>
+                                                </constraints>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="oHa-OG-knM">
+                                                <rect key="frame" x="0.0" y="40" width="290" height="30"/>
+                                                <subviews>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Y79-Ub-iWU">
+                                                        <rect key="frame" x="0.0" y="0.0" width="137.5" height="30"/>
+                                                        <color key="backgroundColor" red="0.0" green="0.80000000000000004" blue="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <fontDescription key="fontDescription" name="Rubik-Medium" family="Rubik" pointSize="12"/>
+                                                        <state key="normal" title="SOLUTIONS">
+                                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                        </state>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                                <integer key="value" value="15"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                        </userDefinedRuntimeAttributes>
+                                                        <connections>
+                                                            <action selector="showSolutions:" destination="3z8-h4-idf" eventType="touchUpInside" id="oZd-gC-Pm1"/>
+                                                        </connections>
+                                                    </button>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="54i-Ba-yow">
                                                         <rect key="frame" x="152.5" y="0.0" width="137.5" height="30"/>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     </view>
                                                 </subviews>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="30" id="eKV-NR-ww8"/>
+                                                    <constraint firstAttribute="height" constant="30" id="NKz-Vw-kgb"/>
                                                 </constraints>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7fp-Iv-UDG">
-                                                <rect key="frame" x="0.0" y="80" width="290" height="48"/>
+                                                <rect key="frame" x="0.0" y="80" width="290" height="33"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zMy-ns-bte">
-                                                        <rect key="frame" x="0.0" y="0.0" width="290" height="48"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="290" height="33"/>
                                                         <fontDescription key="fontDescription" name="Rubik-Regular" family="Rubik" pointSize="17"/>
                                                         <inset key="contentEdgeInsets" minX="0.0" minY="7" maxX="0.0" maxY="5"/>
                                                         <state key="normal" title="SOLUTIONS" image="ic_lock_outline_18pt">
@@ -1141,6 +1139,7 @@
                                 </constraints>
                             </view>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="xYg-Od-DvE"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="D74-Wv-07Z" firstAttribute="top" secondItem="Vxf-PL-fVq" secondAttribute="bottom" constant="-8" id="2Pd-a7-lQD"/>
@@ -1155,7 +1154,6 @@
                             <constraint firstItem="D74-Wv-07Z" firstAttribute="leading" secondItem="xYg-Od-DvE" secondAttribute="leading" id="ty6-jT-1eM"/>
                             <constraint firstItem="xYg-Od-DvE" firstAttribute="trailing" secondItem="D74-Wv-07Z" secondAttribute="trailing" id="vYj-0g-f3Q"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="xYg-Od-DvE"/>
                     </view>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <size key="freeformSize" width="320" height="800"/>
@@ -1201,8 +1199,8 @@
                     <view key="view" contentMode="scaleToFill" id="oYG-1N-NUp">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <viewLayoutGuide key="safeArea" id="5mI-ei-zcp"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </view>
                     <navigationItem key="navigationItem" title="Solutions" id="eKO-XP-b8c">
                         <barButtonItem key="leftBarButtonItem" image="ic_navigate_before_36pt" style="done" id="nyJ-qG-nlK">
@@ -1225,7 +1223,7 @@
             <objects>
                 <navigationController storyboardIdentifier="ReviewNavigationViewController" modalPresentationStyle="fullScreen" id="dxf-Xr-dqr" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="oVT-H4-q2N">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -1245,7 +1243,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fRi-gR-yd2">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="518"/>
+                                <rect key="frame" x="0.0" y="20" width="320" height="498"/>
                             </containerView>
                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Qv7-B6-GTS">
                                 <rect key="frame" x="0.0" y="518" width="320" height="50"/>
@@ -1260,7 +1258,7 @@
                                                         <rect key="frame" x="0.0" y="13" width="24" height="24"/>
                                                         <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                     </imageView>
-                                                    <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KYP-dB-Ug5">
+                                                    <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KYP-dB-Ug5">
                                                         <rect key="frame" x="24" y="10" width="40" height="30"/>
                                                         <fontDescription key="fontDescription" name="Rubik-Medium" family="Rubik" pointSize="15"/>
                                                         <state key="normal" title="PREV"/>
@@ -1273,7 +1271,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="KPx-VB-QV3">
                                                 <rect key="frame" x="257" y="0.0" width="63" height="50"/>
                                                 <subviews>
-                                                    <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="V4M-k5-4EG">
+                                                    <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="V4M-k5-4EG">
                                                         <rect key="frame" x="0.0" y="10" width="39" height="30"/>
                                                         <fontDescription key="fontDescription" name="Rubik-Medium" family="Rubik" pointSize="15"/>
                                                         <state key="normal" title="NEXT"/>
@@ -1287,7 +1285,7 @@
                                                     <constraint firstAttribute="width" constant="63" id="Hq2-QI-2Sx"/>
                                                 </constraints>
                                             </stackView>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IBv-jj-sfW">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IBv-jj-sfW">
                                                 <rect key="frame" x="84" y="10" width="153" height="30"/>
                                                 <color key="backgroundColor" red="0.0" green="0.80000000000000004" blue="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" name="Rubik-Medium" family="Rubik" pointSize="12"/>
@@ -1322,6 +1320,7 @@
                                 </subviews>
                             </stackView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="gGO-pG-y1K"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="Qv7-B6-GTS" firstAttribute="top" secondItem="fRi-gR-yd2" secondAttribute="bottom" id="1K7-bu-bNN"/>
@@ -1332,7 +1331,6 @@
                             <constraint firstItem="fRi-gR-yd2" firstAttribute="leading" secondItem="Qv7-B6-GTS" secondAttribute="leading" id="Wi6-cW-s5h"/>
                             <constraint firstItem="gGO-pG-y1K" firstAttribute="trailing" secondItem="Qv7-B6-GTS" secondAttribute="trailing" id="knZ-bH-jRD"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="gGO-pG-y1K"/>
                     </view>
                     <connections>
                         <outlet property="nextArrow" destination="gLV-q5-g7j" id="ZTA-fI-dab"/>
@@ -1364,17 +1362,18 @@
                                 </constraints>
                             </view>
                             <view alpha="0.10000000149011612" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vPX-Su-VgR">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="8"/>
+                                <rect key="frame" x="0.0" y="20" width="320" height="8"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="8" id="tHp-TJ-d2P"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1qI-Ny-he3">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                                <rect key="frame" x="0.0" y="20" width="320" height="548"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </view>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="XJJ-yz-UXU"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="XJJ-yz-UXU" firstAttribute="trailing" secondItem="vPX-Su-VgR" secondAttribute="trailing" id="3yy-zC-OmQ"/>
@@ -1388,7 +1387,6 @@
                             <constraint firstItem="tOm-Ue-6e4" firstAttribute="leading" secondItem="XJJ-yz-UXU" secondAttribute="leading" id="qVQ-Xw-IlN"/>
                             <constraint firstAttribute="bottom" secondItem="tOm-Ue-6e4" secondAttribute="bottom" id="uDs-tL-zP7"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="XJJ-yz-UXU"/>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
                                 <integer key="value" value="5"/>
@@ -1423,7 +1421,7 @@
                                             <constraint firstAttribute="height" constant="8" id="Ei2-Gy-ivv"/>
                                         </constraints>
                                     </view>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DCu-62-YBP">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DCu-62-YBP">
                                         <rect key="frame" x="20" y="18" width="280" height="30"/>
                                         <color key="backgroundColor" red="0.0" green="0.80000000000000004" blue="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" name="Rubik-Medium" family="Rubik" pointSize="12"/>
@@ -1453,10 +1451,11 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PjU-XF-VZS">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="518"/>
+                                <rect key="frame" x="0.0" y="20" width="320" height="498"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </view>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="g3t-h3-KhS"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="PjU-XF-VZS" firstAttribute="top" secondItem="g3t-h3-KhS" secondAttribute="top" id="DIv-KY-QkI"/>
@@ -1467,7 +1466,6 @@
                             <constraint firstItem="g3t-h3-KhS" firstAttribute="bottom" secondItem="8PC-Se-pbC" secondAttribute="bottom" id="j6z-dH-0ga"/>
                             <constraint firstItem="PjU-XF-VZS" firstAttribute="leading" secondItem="g3t-h3-KhS" secondAttribute="leading" id="krr-Bz-P5K"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="g3t-h3-KhS"/>
                     </view>
                     <connections>
                         <outlet property="bottomShadowView" destination="Mcb-yf-35t" id="RVd-gT-gDE"/>
@@ -1488,10 +1486,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gOC-Gm-4pr">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                                <rect key="frame" x="0.0" y="20" width="320" height="548"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LGX-Lf-REP">
-                                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="320" height="548"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalCentering" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="dvu-M9-KyJ">
                                                 <rect key="frame" x="0.0" y="20" width="300" height="336"/>
@@ -1588,6 +1586,7 @@
                                 </constraints>
                             </scrollView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="twh-Ud-4Ru"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="gOC-Gm-4pr" firstAttribute="top" secondItem="twh-Ud-4Ru" secondAttribute="top" id="ASK-Q8-pkG"/>
@@ -1597,7 +1596,6 @@
                             <constraint firstItem="twh-Ud-4Ru" firstAttribute="trailing" secondItem="gOC-Gm-4pr" secondAttribute="trailing" id="fyC-qE-JVQ"/>
                             <constraint firstItem="LGX-Lf-REP" firstAttribute="width" secondItem="twh-Ud-4Ru" secondAttribute="width" id="vrb-ch-EK3"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="twh-Ud-4Ru"/>
                     </view>
                     <connections>
                         <outlet property="chartView" destination="ufy-MF-WA0" id="Won-AV-8js"/>
@@ -1621,7 +1619,7 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="bottom" selectionStyle="default" indentationWidth="10" reuseIdentifier="SubjectAnalyticsHeader" rowHeight="55" id="JLl-la-hQe">
-                                <rect key="frame" x="0.0" y="28" width="320" height="55"/>
+                                <rect key="frame" x="0.0" y="50" width="320" height="55"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="JLl-la-hQe" id="0IE-78-ntr">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="55"/>
@@ -1690,7 +1688,7 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="IndividualSubjectAnalyticsCountCell" rowHeight="62" id="IZJ-M8-nYD" customClass="IndividualSubjectAnalyticsCountCell" customModule="ios_app" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="83" width="320" height="62"/>
+                                <rect key="frame" x="0.0" y="105" width="320" height="62"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="IZJ-M8-nYD" id="THv-ol-98L">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="62"/>
@@ -1762,7 +1760,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="IndividualSubjectAnalyticsGraphCell" rowHeight="271" id="1uY-d0-37L" customClass="IndividualSubjectAnalyticsGraphCell" customModule="ios_app" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="145" width="320" height="271"/>
+                                <rect key="frame" x="0.0" y="167" width="320" height="271"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="1uY-d0-37L" id="fje-Nc-GXP">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="271"/>
@@ -1992,7 +1990,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qzJ-ZH-DBQ">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                                <rect key="frame" x="0.0" y="20" width="320" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="0Rt-9n-md5"/>
                                 </constraints>
@@ -2008,7 +2006,7 @@
                                 </items>
                             </navigationBar>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DOz-Xx-JC4">
-                                <rect key="frame" x="0.0" y="44" width="320" height="524"/>
+                                <rect key="frame" x="0.0" y="64" width="320" height="504"/>
                                 <subviews>
                                     <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="nBm-6N-5uq" customClass="ButtonBarView" customModule="XLPagerTabStrip">
                                         <rect key="frame" x="0.0" y="0.0" width="320" height="54"/>
@@ -2032,7 +2030,7 @@
                                         </constraints>
                                     </view>
                                     <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CQA-We-K6l" userLabel="Container View">
-                                        <rect key="frame" x="0.0" y="56" width="320" height="468"/>
+                                        <rect key="frame" x="0.0" y="56" width="320" height="448"/>
                                     </scrollView>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -2050,6 +2048,7 @@
                                 </constraints>
                             </view>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="5LW-yO-hok"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="DOz-Xx-JC4" firstAttribute="top" secondItem="qzJ-ZH-DBQ" secondAttribute="bottom" id="39I-Z0-Awa"/>
@@ -2060,7 +2059,6 @@
                             <constraint firstItem="5LW-yO-hok" firstAttribute="bottom" secondItem="DOz-Xx-JC4" secondAttribute="bottom" id="fUA-qQ-akB"/>
                             <constraint firstItem="5LW-yO-hok" firstAttribute="trailing" secondItem="qzJ-ZH-DBQ" secondAttribute="trailing" id="gnf-uE-6U2"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="5LW-yO-hok"/>
                     </view>
                     <navigationItem key="navigationItem" id="B6l-oU-jDE"/>
                     <connections>
@@ -2082,7 +2080,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5Y1-0P-pwV">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                                <rect key="frame" x="0.0" y="20" width="320" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="apm-YX-Fj1"/>
                                 </constraints>
@@ -2098,7 +2096,7 @@
                                 </items>
                             </navigationBar>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BHO-SL-XKh">
-                                <rect key="frame" x="0.0" y="44" width="320" height="524"/>
+                                <rect key="frame" x="0.0" y="64" width="320" height="504"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Bsr-9I-eRW">
                                         <rect key="frame" x="0.0" y="0.0" width="320" height="56"/>
@@ -2153,8 +2151,8 @@
                                         </constraints>
                                     </view>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="7Gr-I5-MMx" customClass="LUExpandableTableView" customModule="LUExpandableTableView">
-                                        <rect key="frame" x="0.0" y="56" width="320" height="468"/>
-                                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                                        <rect key="frame" x="0.0" y="56" width="320" height="448"/>
+                                        <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="TimeAnalyticsQuestionCell" rowHeight="62" id="bev-r1-igj" customClass="TimeAnalyticsQuestionCell" customModule="ios_app" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="55.5" width="320" height="62"/>
@@ -2179,6 +2177,7 @@
                                 </constraints>
                             </view>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="UVt-8x-4qo"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="BHO-SL-XKh" firstAttribute="top" secondItem="5Y1-0P-pwV" secondAttribute="bottom" id="F2m-1E-Xkg"/>
@@ -2189,7 +2188,6 @@
                             <constraint firstItem="UVt-8x-4qo" firstAttribute="bottom" secondItem="BHO-SL-XKh" secondAttribute="bottom" id="qoj-gN-BEB"/>
                             <constraint firstItem="BHO-SL-XKh" firstAttribute="leading" secondItem="UVt-8x-4qo" secondAttribute="leading" id="xLk-Mn-Ada"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="UVt-8x-4qo"/>
                     </view>
                     <connections>
                         <outlet property="contentView" destination="BHO-SL-XKh" id="VeL-ML-cQF"/>
@@ -2213,10 +2211,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="517-8O-Ws1">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                                <rect key="frame" x="0.0" y="20" width="320" height="548"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KNe-Fo-6TG">
-                                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="320" height="548"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="56" translatesAutoresizingMaskIntoConstraints="NO" id="w8y-Z7-8Fe">
                                                 <rect key="frame" x="25" y="0.0" width="270" height="519"/>
@@ -2316,7 +2314,7 @@ You’ve earned</string>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="LQ1-Aw-9Ht">
                                                         <rect key="frame" x="0.0" y="458" width="270" height="61"/>
                                                         <subviews>
-                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PST-32-dy4">
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PST-32-dy4">
                                                                 <rect key="frame" x="0.0" y="0.0" width="270" height="40"/>
                                                                 <color key="backgroundColor" red="0.0" green="0.80000000000000004" blue="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <constraints>
@@ -2365,6 +2363,7 @@ You’ve earned</string>
                                 </constraints>
                             </scrollView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="x16-uo-Fuw"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="x16-uo-Fuw" firstAttribute="bottom" secondItem="517-8O-Ws1" secondAttribute="bottom" id="323-Ng-fU2"/>
@@ -2374,7 +2373,6 @@ You’ve earned</string>
                             <constraint firstItem="KNe-Fo-6TG" firstAttribute="width" secondItem="1P6-Qe-OEN" secondAttribute="width" id="dkB-Qb-VaL"/>
                             <constraint firstItem="517-8O-Ws1" firstAttribute="leading" secondItem="x16-uo-Fuw" secondAttribute="leading" id="fzP-od-1QJ"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="x16-uo-Fuw"/>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
                                 <integer key="value" value="5"/>
@@ -2398,22 +2396,25 @@ You’ve earned</string>
         </scene>
     </scenes>
     <resources>
-        <image name="accurate_flat_icon" width="66" height="72"/>
-        <image name="clock_flat_icon" width="66" height="72"/>
-        <image name="correct_flat_icon" width="56" height="72"/>
-        <image name="cutoff_flat_icon" width="400.69564819335938" height="400.69564819335938"/>
-        <image name="ic_lock_outline_18pt" width="36" height="36"/>
-        <image name="ic_navigate_before" width="48" height="48"/>
-        <image name="ic_navigate_before_36pt" width="72" height="72"/>
-        <image name="ic_navigate_next" width="48" height="48"/>
-        <image name="incorrect_flat_icon" width="56" height="72"/>
-        <image name="percentage_badge_flat_icon" width="384" height="384"/>
+        <image name="accurate_flat_icon" width="33" height="36"/>
+        <image name="clock_flat_icon" width="33" height="36"/>
+        <image name="correct_flat_icon" width="28" height="36"/>
+        <image name="cutoff_flat_icon" width="128" height="128"/>
+        <image name="ic_lock_outline_18pt" width="18" height="18"/>
+        <image name="ic_navigate_before" width="24" height="24"/>
+        <image name="ic_navigate_before_36pt" width="36" height="36"/>
+        <image name="ic_navigate_next" width="24" height="24"/>
+        <image name="incorrect_flat_icon" width="28" height="36"/>
+        <image name="percentage_badge_flat_icon" width="128" height="128"/>
         <image name="percentile_flat_icon" width="128" height="128"/>
         <image name="questions_flat_icon" width="128" height="128"/>
         <image name="rank_flat_icon" width="108" height="96"/>
         <image name="score_flat_icon" width="102" height="108"/>
         <image name="stopwatch_flat_icon" width="128" height="128"/>
         <image name="total_marks_flat_icon" width="128" height="128"/>
-        <image name="trophy_flat_icon" width="110" height="128"/>
+        <image name="trophy_flat_icon" width="55" height="64"/>
+        <systemColor name="groupTableViewBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
- Previously we had the Solution button declared in the Analyts layout and the Time analytic button in the Solution layout. 
- So we are not able to handle the button visibility according to exam settings.
- However, in this commit, we have relocated the buttons to their respective layouts.