### PR TITLE
fix: Analytics button showing when Analytics is disable in exam settings

### DIFF
--- a/ios-app/AppDelegate.swift
+++ b/ios-app/AppDelegate.swift
@@ -116,7 +116,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             SentrySDK.setUser(user)
         }
         
-        let config = Realm.Configuration(schemaVersion: 27)
+        let config = Realm.Configuration(schemaVersion: 28)
         Realm.Configuration.defaultConfiguration = config
         let viewController:UIViewController
         

--- a/ios-app/Model/Exam.swift
+++ b/ios-app/Model/Exam.swift
@@ -60,6 +60,7 @@ class Exam: DBModel {
     @objc dynamic var studentsAttemptedCount: Int = 0
     @objc dynamic var isGrowthHackEnabled: Bool = false;
     @objc dynamic var shareTextForSolutionUnlock: String = "";
+    @objc dynamic var showAnalytics: Bool = false
     
     override public static func primaryKey() -> String? {
         return "id"
@@ -102,6 +103,7 @@ class Exam: DBModel {
         isGrowthHackEnabled <- map["is_growth_hack_enabled"]
         shareTextForSolutionUnlock <- map["share_text_for_solution_unlock"]
         examDescription <- map["description"]
+        showAnalytics <- map["show_analytics"]
     }
     
     func hasStarted() -> Bool {

--- a/ios-app/UI/TestReportViewController.swift
+++ b/ios-app/UI/TestReportViewController.swift
@@ -116,7 +116,7 @@ class TestReportViewController: UIViewController {
             shareButton.imageEdgeInsets = UIEdgeInsets(top: 0, left: -10, bottom: 0, right: 0)
         } else {
             shareButtonLayout.isHidden = true
-            analyticsButtonLayout.isHidden = false
+            showOrHideAnalytics()
             solutionButtonLayout.isHidden = false
             solutionsButton.setImage(nil, for: .normal)
         }
@@ -135,6 +135,14 @@ class TestReportViewController: UIViewController {
             }
         }
         self.present(viewController, animated: true, completion: nil)
+    }
+    
+    private func showOrHideAnalytics() {
+        if (exam.showAnalytics) {
+            analyticsButtonLayout.isHidden = false
+        } else {
+            analyticsButtonLayout.isHidden = true
+        }
     }
     
     @IBAction func showSolutions(_ sender: UIButton) {


### PR DESCRIPTION
- Analytics button is always showing because we did not handle this using showAnalytics field in the exam model
- Added showAnalytics filed in the exam model
- In this commit, we handled analyticsButtonLayout using showAnalytics field

