### PR TITLE
fix: Add support open exam review page without exam object

### DIFF
--- a/ios-app/UI/TestReportViewController.swift
+++ b/ios-app/UI/TestReportViewController.swift
@@ -67,24 +67,7 @@ class TestReportViewController: UIViewController {
         date.text = FormatDate.format(dateString: attempt!.date!,
                                       givenFormat: "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
 
-        if(exam != nil){
-            examTitle.text = exam!.title
-            totalQuestions.text = String(exam!.numberOfQuestions)
-            totalMarks.text = exam!.totalMarks
-            totalTime.text = String(exam!.duration)
-            cutoff.text = String(exam!.passPercentage)
-        } else {
-            examTitle.text = "Custom Module"
-            totalQuestions.text = String(attempt.totalQuestions)
-            totalMarks.text = String("")
-            totalTime.text = String("")
-            cutoff.text = String("")
-        }
-        percentage.text = attempt.percentage
-        correct.text = String(attempt!.correctCount)
-        incorrect.text = String(attempt!.incorrectCount)
-        timeTaken.text = attempt!.timeTaken ?? "NA"
-        accuracy.text = String(attempt!.accuracy) + "%"
+        setExamDetails()
         UIUtils.setButtonDropShadow(solutionsButton)
         UIUtils.setButtonDropShadow(analyticsButton)
         UIUtils.setButtonDropShadow(timeAnalyticsButton)
@@ -98,6 +81,19 @@ class TestReportViewController: UIViewController {
         showOrHideLockIconInSolutionButton()
     }
     
+    private func setExamDetails() {
+        examTitle.text = exam?.title ?? "Custom Module"
+        totalQuestions.text = String(exam?.numberOfQuestions ?? attempt.totalQuestions)
+        totalMarks.text = exam?.totalMarks ?? ""
+        totalTime.text = exam?.duration ?? ""
+        cutoff.text = String(exam?.passPercentage ?? 0.0)
+        percentage.text = attempt.percentage
+        correct.text = String(attempt!.correctCount)
+        incorrect.text = String(attempt!.incorrectCount)
+        timeTaken.text = attempt!.timeTaken ?? "NA"
+        accuracy.text = String(attempt!.accuracy) + "%"
+    }
+    
     func showOrHideRank() {
         if attempt.rankEnabled {
             rank.text = String.getValue(attempt!.rank)
@@ -108,20 +104,18 @@ class TestReportViewController: UIViewController {
     }
 
     func showOrHideScore() {
-        if exam == nil {
-            score.text = attempt.score!
-        } else if exam!.showScore && attempt.hasScore() {
-            score.text = attempt.score!
+        if let attemptScore = attempt.score, (exam == nil || exam!.showScore && attempt.hasScore()) {
+            score.text = attemptScore
+            scoreLayout.isHidden = false
         } else {
             scoreLayout.isHidden = true
         }
     }
 
     func showOrHidePercentile() {
-        if exam == nil {
-            percentileLayout.isHidden = true
-        } else if exam!.showPercentile && attempt.percentile != 0 {
+        if let exam = exam, exam.showPercentile, attempt.percentile != 0 {
             percentile.text = String(attempt.percentile)
+            percentileLayout.isHidden = false
         } else {
             percentileLayout.isHidden = true
         }
@@ -146,12 +140,10 @@ class TestReportViewController: UIViewController {
     }
 
     private func showOrHideSolutions() {
-        if exam == nil {
-            solutionButtonLayout.isHidden = false
-        }else if (exam!.showAnswers) {
-            solutionButtonLayout.isHidden = false
-        } else {
+        if (exam != nil && !exam!.showAnswers) {
             solutionButtonLayout.isHidden = true
+        } else {
+            solutionButtonLayout.isHidden = false
         }
     }
 
@@ -172,12 +164,10 @@ class TestReportViewController: UIViewController {
     }
     
     private func showOrHideAnalytics() {
-        if exam == nil {
-            analyticsButtonLayout.isHidden = false
-        }else if (exam!.showAnalytics) {
-            analyticsButtonLayout.isHidden = false
-        } else {
+        if (exam != nil && !exam!.showAnalytics) {
             analyticsButtonLayout.isHidden = true
+        } else {
+            analyticsButtonLayout.isHidden = false
         }
     }
     

--- a/ios-app/UI/TestReportViewController.swift
+++ b/ios-app/UI/TestReportViewController.swift
@@ -261,7 +261,7 @@ class TestReportViewController: UIViewController {
             contentDetailPageViewController as! ContentDetailPageViewController
         
         contentDetailPageViewController.dismiss(animated: false, completion: {
-            if Double(self.attempt.percentage) ?? 0 >= self.exam!.passPercentage {
+            if Double(self.attempt.percentage) ?? 0 >= self.exam?.passPercentage ?? 0 {
                 let currentIndex = contentDetailPageViewController.getCurrentIndex()
                 let nextContent =
                     contentDetailPageViewController.contents[currentIndex]

--- a/ios-app/UI/TestReportViewController.swift
+++ b/ios-app/UI/TestReportViewController.swift
@@ -127,7 +127,7 @@ class TestReportViewController: UIViewController {
     }
     
     func showOrHideLockIconInSolutionButton() {
-        if (exam != nil && (exam!.isGrowthHackEnabled ?? false) && (exam!.getNumberOfTimesShared() < 2)) {
+        if (exam != nil && (exam!.isGrowthHackEnabled) && (exam!.getNumberOfTimesShared() < 2)) {
             shareButtonLayout.isHidden = false
             analyticsButtonLayout.isHidden = true
             solutionButtonLayout.isHidden = true
@@ -158,7 +158,7 @@ class TestReportViewController: UIViewController {
         let storyboard = UIStoryboard(name: Constants.MAIN_STORYBOARD, bundle: nil)
         let viewController = storyboard.instantiateViewController(withIdentifier:
             Constants.SHARE_TO_UNLOCK_VIEW_CONTROLLER) as! ShareToUnlockViewController
-        viewController.shareText = exam!.shareTextForSolutionUnlock ?? ""
+        viewController.shareText = exam!.shareTextForSolutionUnlock
         viewController.onShareCompletion = {
             self.exam!.incrementNumberOfTimesShared()
             if (self.exam!.getNumberOfTimesShared() >= 2) {

--- a/ios-app/UI/TestReportViewController.swift
+++ b/ios-app/UI/TestReportViewController.swift
@@ -76,10 +76,11 @@ class TestReportViewController: UIViewController {
         } else {
             examTitle.text = "Custom Module"
             totalQuestions.text = String(attempt.totalQuestions)
-            totalMarks.text = String("NA")
-            totalTime.text = String("NA")
-            cutoff.text = String("NA")
+            totalMarks.text = String("")
+            totalTime.text = String("")
+            cutoff.text = String("")
         }
+        percentage.text = attempt.percentage
         correct.text = String(attempt!.correctCount)
         incorrect.text = String(attempt!.incorrectCount)
         timeTaken.text = attempt!.timeTaken ?? "NA"

--- a/ios-app/UI/TestReportViewController.swift
+++ b/ios-app/UI/TestReportViewController.swift
@@ -96,7 +96,7 @@ class TestReportViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         showOrHideLockIconInSolutionButton()
     }
-
+    
     func showOrHideRank() {
         if attempt.rankEnabled {
             rank.text = String.getValue(attempt!.rank)
@@ -125,7 +125,7 @@ class TestReportViewController: UIViewController {
             percentileLayout.isHidden = true
         }
     }
-
+    
     func showOrHideLockIconInSolutionButton() {
         if (exam != nil && (exam!.isGrowthHackEnabled ?? false) && (exam!.getNumberOfTimesShared() < 2)) {
             shareButtonLayout.isHidden = false
@@ -184,7 +184,7 @@ class TestReportViewController: UIViewController {
         showSolutionsScreen()
     }
 
-
+    
     func showSolutionsScreen() {
         let slideMenuController = self.storyboard?.instantiateViewController(withIdentifier:
         Constants.REVIEW_NAVIGATION_VIEW_CONTROLLER) as! UINavigationController
@@ -200,11 +200,11 @@ class TestReportViewController: UIViewController {
     @IBAction func showSubjectAnalytics(_ sender: UIButton) {
         let viewController = self.storyboard?.instantiateViewController(withIdentifier:
             Constants.SUBJECT_ANALYTICS_TAB_VIEW_CONTROLLER) as! SubjectAnalyticsTabViewController
-
+        
         viewController.analyticsUrl = attempt!.url + TPEndpoint.getAttemptSubjectAnalytics.urlPath
         present(viewController, animated: true, completion: nil)
     }
-
+    
     @IBAction func showTimeAnalytics(_ sender: UIButton) {
         let viewController = self.storyboard?.instantiateViewController(withIdentifier:
             Constants.TIME_ANALYTICS_TABLE_VIEW_CONTROLLER) as! TimeAnalyticsTableViewController
@@ -212,7 +212,7 @@ class TestReportViewController: UIViewController {
         viewController.attempt = attempt
         present(viewController, animated: true, completion: nil)
     }
-
+    
     @IBAction func back(_ sender: UIBarButtonItem) {
         let presentingViewController =
             self.presentingViewController?.presentingViewController?.presentingViewController
@@ -254,7 +254,7 @@ class TestReportViewController: UIViewController {
             dismiss(animated: true, completion: nil)
         }
     }
-
+    
     func goToContentDetailPageViewController(_ contentDetailPageViewController: UIViewController) {
         let contentDetailPageViewController =
             contentDetailPageViewController as! ContentDetailPageViewController
@@ -271,7 +271,7 @@ class TestReportViewController: UIViewController {
             contentDetailPageViewController.updateCurrentExamContent()
         })
     }
-
+    
     func goToAccessCodeExamsViewController(_ viewController: AccessCodeExamsViewController) {
         viewController.items.removeAll()
         viewController.dismiss(animated: false, completion: nil)
@@ -284,7 +284,7 @@ class TestReportViewController: UIViewController {
         bottomGradient.frame = bottomShadowView.bounds
         bottomGradient.colors = [UIColor.white.cgColor, UIColor.black.cgColor]
         bottomShadowView.layer.addSublayer(bottomGradient)
-
+        
         // Set scroll view content height to support the scroll
         scrollView.contentSize.height = contentView.frame.size.height
     }

--- a/ios-app/UI/TestReportViewController.swift
+++ b/ios-app/UI/TestReportViewController.swift
@@ -64,7 +64,7 @@ class TestReportViewController: UIViewController {
         super.viewDidLoad()
         self.setStatusBarColor()
 
-        
+
         examTitle.text = exam!.title
         date.text = FormatDate.format(dateString: attempt!.date!,
                                       givenFormat: "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
@@ -170,7 +170,7 @@ class TestReportViewController: UIViewController {
         showSolutionsScreen()
     }
 
-    
+
     func showSolutionsScreen() {
         let slideMenuController = self.storyboard?.instantiateViewController(withIdentifier:
         Constants.REVIEW_NAVIGATION_VIEW_CONTROLLER) as! UINavigationController
@@ -186,19 +186,19 @@ class TestReportViewController: UIViewController {
     @IBAction func showSubjectAnalytics(_ sender: UIButton) {
         let viewController = self.storyboard?.instantiateViewController(withIdentifier:
             Constants.SUBJECT_ANALYTICS_TAB_VIEW_CONTROLLER) as! SubjectAnalyticsTabViewController
-        
+
         viewController.analyticsUrl = attempt!.url + TPEndpoint.getAttemptSubjectAnalytics.urlPath
         present(viewController, animated: true, completion: nil)
     }
-    
+
     @IBAction func showTimeAnalytics(_ sender: UIButton) {
         let viewController = self.storyboard?.instantiateViewController(withIdentifier:
             Constants.TIME_ANALYTICS_TABLE_VIEW_CONTROLLER) as! TimeAnalyticsTableViewController
-        
+
         viewController.attempt = attempt
         present(viewController, animated: true, completion: nil)
     }
-    
+
     @IBAction func back(_ sender: UIBarButtonItem) {
         let presentingViewController =
             self.presentingViewController?.presentingViewController?.presentingViewController
@@ -240,7 +240,7 @@ class TestReportViewController: UIViewController {
             dismiss(animated: true, completion: nil)
         }
     }
-    
+
     func goToContentDetailPageViewController(_ contentDetailPageViewController: UIViewController) {
         let contentDetailPageViewController =
             contentDetailPageViewController as! ContentDetailPageViewController
@@ -257,12 +257,12 @@ class TestReportViewController: UIViewController {
             contentDetailPageViewController.updateCurrentExamContent()
         })
     }
-    
+
     func goToAccessCodeExamsViewController(_ viewController: AccessCodeExamsViewController) {
         viewController.items.removeAll()
         viewController.dismiss(animated: false, completion: nil)
     }
-    
+
     // Set frames of the views in this method to support both portrait & landscape view
     override func viewDidLayoutSubviews() {
         // Add gradient shadow layer to the shadow container view
@@ -270,7 +270,7 @@ class TestReportViewController: UIViewController {
         bottomGradient.frame = bottomShadowView.bounds
         bottomGradient.colors = [UIColor.white.cgColor, UIColor.black.cgColor]
         bottomShadowView.layer.addSublayer(bottomGradient)
-        
+
         // Set scroll view content height to support the scroll
         scrollView.contentSize.height = contentView.frame.size.height
     }

--- a/ios-app/UI/TestReportViewController.swift
+++ b/ios-app/UI/TestReportViewController.swift
@@ -104,18 +104,18 @@ class TestReportViewController: UIViewController {
     }
 
     func showOrHideScore() {
-        if let attemptScore = attempt.score, (exam == nil || exam!.showScore && attempt.hasScore()) {
-            score.text = attemptScore
-            scoreLayout.isHidden = false
+        if exam == nil {
+            score.text = attempt.score!
+        } else if exam!.showScore && attempt.hasScore() {
+            score.text = attempt.score!
         } else {
             scoreLayout.isHidden = true
         }
     }
 
     func showOrHidePercentile() {
-        if let exam = exam, exam.showPercentile, attempt.percentile != 0 {
+        if exam != nil && exam!.showPercentile && attempt.percentile != 0 {
             percentile.text = String(attempt.percentile)
-            percentileLayout.isHidden = false
         } else {
             percentileLayout.isHidden = true
         }

--- a/ios-app/UI/TestReportViewController.swift
+++ b/ios-app/UI/TestReportViewController.swift
@@ -208,7 +208,7 @@ class TestReportViewController: UIViewController {
     @IBAction func showTimeAnalytics(_ sender: UIButton) {
         let viewController = self.storyboard?.instantiateViewController(withIdentifier:
             Constants.TIME_ANALYTICS_TABLE_VIEW_CONTROLLER) as! TimeAnalyticsTableViewController
-
+        
         viewController.attempt = attempt
         present(viewController, animated: true, completion: nil)
     }
@@ -276,7 +276,7 @@ class TestReportViewController: UIViewController {
         viewController.items.removeAll()
         viewController.dismiss(animated: false, completion: nil)
     }
-
+    
     // Set frames of the views in this method to support both portrait & landscape view
     override func viewDidLayoutSubviews() {
         // Add gradient shadow layer to the shadow container view

--- a/ios-app/UI/TestReportViewController.swift
+++ b/ios-app/UI/TestReportViewController.swift
@@ -68,7 +68,7 @@ class TestReportViewController: UIViewController {
         examTitle.text = exam!.title
         date.text = FormatDate.format(dateString: attempt!.date!,
                                       givenFormat: "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
-        
+
         totalQuestions.text = String(exam.numberOfQuestions)
         totalMarks.text = exam.totalMarks
         totalTime.text = String(exam.duration)
@@ -90,7 +90,7 @@ class TestReportViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         showOrHideLockIconInSolutionButton()
     }
-    
+
     func showOrHideRank() {
         if attempt.rankEnabled {
             rank.text = String.getValue(attempt!.rank)
@@ -115,7 +115,7 @@ class TestReportViewController: UIViewController {
             percentileLayout.isHidden = true
         }
     }
-    
+
     func showOrHideLockIconInSolutionButton() {
         if ((exam.isGrowthHackEnabled ?? false) && (exam.getNumberOfTimesShared() < 2)) {
             shareButtonLayout.isHidden = false

--- a/ios-app/UI/TestReportViewController.swift
+++ b/ios-app/UI/TestReportViewController.swift
@@ -58,22 +58,28 @@ class TestReportViewController: UIViewController {
     @IBOutlet weak var shareButtonLayout: UIStackView!
     
     var attempt: Attempt!
-    var exam: Exam!
+    var exam: Exam?
     
     override func viewDidLoad() {
         super.viewDidLoad()
         self.setStatusBarColor()
 
-
-        examTitle.text = exam!.title
         date.text = FormatDate.format(dateString: attempt!.date!,
                                       givenFormat: "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
 
-        totalQuestions.text = String(exam.numberOfQuestions)
-        totalMarks.text = exam.totalMarks
-        totalTime.text = String(exam.duration)
-        percentage.text = attempt.percentage
-        cutoff.text = String(exam.passPercentage)
+        if(exam != nil){
+            examTitle.text = exam!.title
+            totalQuestions.text = String(exam!.numberOfQuestions)
+            totalMarks.text = exam!.totalMarks
+            totalTime.text = String(exam!.duration)
+            cutoff.text = String(exam!.passPercentage)
+        } else {
+            examTitle.text = "Custom Module"
+            totalQuestions.text = String(attempt.totalQuestions)
+            totalMarks.text = String("NA")
+            totalTime.text = String("NA")
+            cutoff.text = String("NA")
+        }
         correct.text = String(attempt!.correctCount)
         incorrect.text = String(attempt!.incorrectCount)
         timeTaken.text = attempt!.timeTaken ?? "NA"
@@ -101,7 +107,9 @@ class TestReportViewController: UIViewController {
     }
 
     func showOrHideScore() {
-        if exam.showScore && attempt.hasScore() {
+        if exam == nil {
+            score.text = attempt.score!
+        } else if exam!.showScore && attempt.hasScore() {
             score.text = attempt.score!
         } else {
             scoreLayout.isHidden = true
@@ -109,7 +117,9 @@ class TestReportViewController: UIViewController {
     }
 
     func showOrHidePercentile() {
-        if exam.showPercentile && attempt.percentile != 0 {
+        if exam == nil {
+            percentileLayout.isHidden = true
+        } else if exam!.showPercentile && attempt.percentile != 0 {
             percentile.text = String(attempt.percentile)
         } else {
             percentileLayout.isHidden = true
@@ -117,7 +127,7 @@ class TestReportViewController: UIViewController {
     }
 
     func showOrHideLockIconInSolutionButton() {
-        if ((exam.isGrowthHackEnabled ?? false) && (exam.getNumberOfTimesShared() < 2)) {
+        if (exam != nil && (exam!.isGrowthHackEnabled ?? false) && (exam!.getNumberOfTimesShared() < 2)) {
             shareButtonLayout.isHidden = false
             analyticsButtonLayout.isHidden = true
             solutionButtonLayout.isHidden = true
@@ -135,7 +145,9 @@ class TestReportViewController: UIViewController {
     }
 
     private func showOrHideSolutions() {
-        if (exam.showAnswers) {
+        if exam == nil {
+            solutionButtonLayout.isHidden = false
+        }else if (exam!.showAnswers) {
             solutionButtonLayout.isHidden = false
         } else {
             solutionButtonLayout.isHidden = true
@@ -146,10 +158,10 @@ class TestReportViewController: UIViewController {
         let storyboard = UIStoryboard(name: Constants.MAIN_STORYBOARD, bundle: nil)
         let viewController = storyboard.instantiateViewController(withIdentifier:
             Constants.SHARE_TO_UNLOCK_VIEW_CONTROLLER) as! ShareToUnlockViewController
-        viewController.shareText = exam.shareTextForSolutionUnlock ?? ""
+        viewController.shareText = exam!.shareTextForSolutionUnlock ?? ""
         viewController.onShareCompletion = {
-            self.exam.incrementNumberOfTimesShared()
-            if (self.exam.getNumberOfTimesShared() >= 2) {
+            self.exam!.incrementNumberOfTimesShared()
+            if (self.exam!.getNumberOfTimesShared() >= 2) {
                 viewController.dismiss(animated: false) {
                     self.showSolutionsScreen()
                 }
@@ -159,7 +171,9 @@ class TestReportViewController: UIViewController {
     }
     
     private func showOrHideAnalytics() {
-        if (exam.showAnalytics) {
+        if exam == nil {
+            analyticsButtonLayout.isHidden = false
+        }else if (exam!.showAnalytics) {
             analyticsButtonLayout.isHidden = false
         } else {
             analyticsButtonLayout.isHidden = true
@@ -246,7 +260,7 @@ class TestReportViewController: UIViewController {
             contentDetailPageViewController as! ContentDetailPageViewController
         
         contentDetailPageViewController.dismiss(animated: false, completion: {
-            if Double(self.attempt.percentage) ?? 0 >= self.exam.passPercentage {
+            if Double(self.attempt.percentage) ?? 0 >= self.exam!.passPercentage {
                 let currentIndex = contentDetailPageViewController.getCurrentIndex()
                 let nextContent =
                     contentDetailPageViewController.contents[currentIndex]


### PR DESCRIPTION
- In this commit, we handled TestReportViewController without an exam object because the custom test generation feature does not contain an exam object.