### PR TITLE
fix: Add support to take exam without exam object

### DIFF
--- a/ios-app/UI/BaseQuestionsPageViewController.swift
+++ b/ios-app/UI/BaseQuestionsPageViewController.swift
@@ -46,7 +46,7 @@ class BaseQuestionsPageViewController: UIViewController, UIPageViewControllerDel
     var questionsPageViewDelegate: QuestionsPageViewDelegate?
     var parentviewController: BaseQuestionsSlidingViewController!
     var currentIndex: Int!
-    var exam: Exam!
+    var exam: Exam?
     var attempt: Attempt!
     var attemptItems = [AttemptItem]()
     var courseContent: Content!

--- a/ios-app/UI/BaseQuestionsSlidingViewController.swift
+++ b/ios-app/UI/BaseQuestionsSlidingViewController.swift
@@ -39,7 +39,7 @@ class BaseQuestionsSlidingViewController: SlideMenuController {
     
     @IBOutlet weak var navigationBarItem: UINavigationItem!
     
-    var exam: Exam!
+    var exam: Exam?
     var attempt: Attempt!
     var courseContent: Content!
     var contentAttempt: ContentAttempt!

--- a/ios-app/UI/StartExamScreenViewController.swift
+++ b/ios-app/UI/StartExamScreenViewController.swift
@@ -195,7 +195,7 @@ class StartExamScreenViewController: UIViewController {
         let viewController =
             slideMenuController.viewControllers.first as! TestEngineSlidingViewController
         
-        viewController.exam = exam
+        //viewController.exam = exam
         viewController.attempt = attempt
         viewController.courseContent = content
         viewController.contentAttempt = contentAttempt

--- a/ios-app/UI/StartExamScreenViewController.swift
+++ b/ios-app/UI/StartExamScreenViewController.swift
@@ -195,7 +195,7 @@ class StartExamScreenViewController: UIViewController {
         let viewController =
             slideMenuController.viewControllers.first as! TestEngineSlidingViewController
         
-        //viewController.exam = exam
+        viewController.exam = exam
         viewController.attempt = attempt
         viewController.courseContent = content
         viewController.contentAttempt = contentAttempt

--- a/ios-app/UI/TestEngineViewController.swift
+++ b/ios-app/UI/TestEngineViewController.swift
@@ -65,9 +65,7 @@ class TestEngineViewController: BaseQuestionsPageViewController {
             nextButton.setTitle("END", for: .disabled)
         }
 
-        if(exam == nil) {
-            parentSlidingViewController.remainingTimeLabel.isHidden = true
-        }
+        showOrHideTimer()
     }
     
     private func setupPauseButtonGesture() {
@@ -80,6 +78,12 @@ class TestEngineViewController: BaseQuestionsPageViewController {
         hideDropdownContainer()
         checkExamHasLockedSection()
         setupSectionsDropDown()
+    }
+    
+    private func showOrHideTimer(){
+        if(exam == nil) {
+            parentSlidingViewController.remainingTimeLabel.isHidden = true
+        }
     }
     
     private func hideDropdownContainer() {
@@ -138,10 +142,15 @@ class TestEngineViewController: BaseQuestionsPageViewController {
             }
             self.onSwitchLockedSection(index: index)
         }
-        firstAttemptOfLockedSectionExam =
-        (courseContent != nil && courseContent.attemptsCount <= 1) ||
-        (courseContent == nil && (exam!.attemptsCount == 0 ||
-                                  (exam!.attemptsCount == 1 && exam!.pausedAttemptsCount == 1)))
+        firstAttemptOfLockedSectionExam = isFirstCourseContentAttempt() || isFirstExamAttempt()
+    }
+
+    private func isFirstCourseContentAttempt() -> (Bool) {
+        return (courseContent != nil && courseContent.attemptsCount <= 1)
+    }
+    
+    private func isFirstExamAttempt() -> (Bool) {
+        return (courseContent == nil && (exam!.attemptsCount == 0 || (exam!.attemptsCount == 1 && exam!.pausedAttemptsCount == 1)))
     }
     
     private func setUpDropDownForSections() {

--- a/ios-app/UI/TestEngineViewController.swift
+++ b/ios-app/UI/TestEngineViewController.swift
@@ -59,7 +59,7 @@ class TestEngineViewController: BaseQuestionsPageViewController {
         
         setupPauseButtonGesture()
         initializeDropDownContainerForSections()
-
+        
         if !firstAttemptOfLockedSectionExam {
             nextButton.setTitleColor(Colors.getRGB(Colors.MATERIAL_RED), for: .disabled)
             nextButton.setTitle("END", for: .disabled)
@@ -69,24 +69,24 @@ class TestEngineViewController: BaseQuestionsPageViewController {
             parentSlidingViewController.remainingTimeLabel.isHidden = true
         }
     }
-
+    
     private func setupPauseButtonGesture() {
         let pauseButtonGesture = UITapGestureRecognizer(target: self, action:
             #selector(self.onPressPauseButton(sender:)))
         parentSlidingViewController.pauseButtonLayout.addGestureRecognizer(pauseButtonGesture)
     }
-
+    
     private func initializeDropDownContainerForSections() {
         hideDropdownContainer()
         checkExamHasLockedSection()
         setupSectionsDropDown()
     }
-
+    
     private func hideDropdownContainer() {
         dropdownContainerHeight.constant = 0
         dropdownContainer.isHidden = true
     }
-
+    
     private func checkExamHasLockedSection() {
         sections = Array(attempt.sections)
         if sections.count > 1 {
@@ -101,7 +101,7 @@ class TestEngineViewController: BaseQuestionsPageViewController {
             lockedSectionExam = !unlockedSectionExam;
         }
     }
-
+    
     private func setupSectionsDropDown() {
         if lockedSectionExam {
             setUpDropDownForLockedSections()
@@ -115,7 +115,7 @@ class TestEngineViewController: BaseQuestionsPageViewController {
         plainDropDown.dropDown.selectionBackgroundColor = UIColor.clear
         plainDropDown.dropDown.cellNib =
         UINib(nibName: "LockableSectionDropDownCell", bundle: nil)
-
+        
         plainDropDown.dropDown.customCellConfiguration = {
             (index: Index, item: String, cell: DropDownCell) -> Void in
 
@@ -130,7 +130,7 @@ class TestEngineViewController: BaseQuestionsPageViewController {
         plainDropDown.setCurrentItem(index: currentSection)
         dropdownContainerHeight.constant =
         TestEngineViewController.DROP_DOWN_CONTAINER_HEIGHT
-
+        
         dropdownContainer.isHidden = false
         plainDropDown.dropDown.selectionAction = { (index: Int, item: String) in
             if index == self.currentSection {
@@ -143,7 +143,7 @@ class TestEngineViewController: BaseQuestionsPageViewController {
         (courseContent == nil && (exam!.attemptsCount == 0 ||
                                   (exam!.attemptsCount == 1 && exam!.pausedAttemptsCount == 1)))
     }
-
+    
     private func setUpDropDownForSections() {
         if exam != nil && (exam!.templateType == 2 || unlockedSectionExam) {
             plainDropDown = PlainDropDown(containerView: dropdownContainer)

--- a/ios-app/UI/TestEngineViewController.swift
+++ b/ios-app/UI/TestEngineViewController.swift
@@ -59,30 +59,30 @@ class TestEngineViewController: BaseQuestionsPageViewController {
         
         setupPauseButtonGesture()
         initializeDropDownContainerForSections()
-        
+
         if !firstAttemptOfLockedSectionExam {
             nextButton.setTitleColor(Colors.getRGB(Colors.MATERIAL_RED), for: .disabled)
             nextButton.setTitle("END", for: .disabled)
         }
     }
-    
+
     private func setupPauseButtonGesture() {
         let pauseButtonGesture = UITapGestureRecognizer(target: self, action:
             #selector(self.onPressPauseButton(sender:)))
         parentSlidingViewController.pauseButtonLayout.addGestureRecognizer(pauseButtonGesture)
     }
-    
+
     private func initializeDropDownContainerForSections() {
         hideDropdownContainer()
         checkExamHasLockedSection()
         setupSectionsDropDown()
     }
-    
+
     private func hideDropdownContainer() {
         dropdownContainerHeight.constant = 0
         dropdownContainer.isHidden = true
     }
-    
+
     private func checkExamHasLockedSection() {
         sections = Array(attempt.sections)
         if sections.count > 1 {
@@ -97,7 +97,7 @@ class TestEngineViewController: BaseQuestionsPageViewController {
             lockedSectionExam = !unlockedSectionExam;
         }
     }
-    
+
     private func setupSectionsDropDown() {
         if lockedSectionExam {
             setUpDropDownForLockedSections()
@@ -105,16 +105,16 @@ class TestEngineViewController: BaseQuestionsPageViewController {
             setUpDropDownForSections()
         }
     }
-    
+
     private func setUpDropDownForLockedSections() {
         plainDropDown = PlainDropDown(containerView: dropdownContainer)
         plainDropDown.dropDown.selectionBackgroundColor = UIColor.clear
         plainDropDown.dropDown.cellNib =
         UINib(nibName: "LockableSectionDropDownCell", bundle: nil)
-        
+
         plainDropDown.dropDown.customCellConfiguration = {
             (index: Index, item: String, cell: DropDownCell) -> Void in
-            
+
             let cell = cell as! LockableSectionDropDownCell
             let selectedItemIndex = self.plainDropDown.dropDown.indexForSelectedRow
             cell.initCell(index: index, sectionName: item, selectedItem: selectedItemIndex!)
@@ -126,7 +126,7 @@ class TestEngineViewController: BaseQuestionsPageViewController {
         plainDropDown.setCurrentItem(index: currentSection)
         dropdownContainerHeight.constant =
         TestEngineViewController.DROP_DOWN_CONTAINER_HEIGHT
-        
+
         dropdownContainer.isHidden = false
         plainDropDown.dropDown.selectionAction = { (index: Int, item: String) in
             if index == self.currentSection {
@@ -139,7 +139,7 @@ class TestEngineViewController: BaseQuestionsPageViewController {
         (courseContent == nil && (exam.attemptsCount == 0 ||
                                   (exam.attemptsCount == 1 && exam.pausedAttemptsCount == 1)))
     }
-    
+
     private func setUpDropDownForSections() {
         if exam.templateType == 2 || unlockedSectionExam {
             plainDropDown = PlainDropDown(containerView: dropdownContainer)

--- a/ios-app/UI/TestEngineViewController.swift
+++ b/ios-app/UI/TestEngineViewController.swift
@@ -64,6 +64,10 @@ class TestEngineViewController: BaseQuestionsPageViewController {
             nextButton.setTitleColor(Colors.getRGB(Colors.MATERIAL_RED), for: .disabled)
             nextButton.setTitle("END", for: .disabled)
         }
+
+        if(exam == nil) {
+            parentSlidingViewController.remainingTimeLabel.isHidden = true
+        }
     }
 
     private func setupPauseButtonGesture() {
@@ -136,12 +140,12 @@ class TestEngineViewController: BaseQuestionsPageViewController {
         }
         firstAttemptOfLockedSectionExam =
         (courseContent != nil && courseContent.attemptsCount <= 1) ||
-        (courseContent == nil && (exam.attemptsCount == 0 ||
-                                  (exam.attemptsCount == 1 && exam.pausedAttemptsCount == 1)))
+        (courseContent == nil && (exam!.attemptsCount == 0 ||
+                                  (exam!.attemptsCount == 1 && exam!.pausedAttemptsCount == 1)))
     }
 
     private func setUpDropDownForSections() {
-        if exam.templateType == 2 || unlockedSectionExam {
+        if exam != nil && (exam!.templateType == 2 || unlockedSectionExam) {
             plainDropDown = PlainDropDown(containerView: dropdownContainer)
             plainDropDown.dropDown.selectionAction = { (index: Int, item: String) in
                 self.plainDropDown.titleButton.setTitle(item, for: .normal)
@@ -492,6 +496,10 @@ class TestEngineViewController: BaseQuestionsPageViewController {
     }
     
     @objc func onPressPauseButton(sender: UITapGestureRecognizer) {
+        if exam == nil {
+            showEndExamDialog()
+            return
+        }
         alertDialog = UIAlertController(title: Strings.EXIT_EXAM,
                                       message: Strings.PAUSE_MESSAGE,
                                       preferredStyle: .alert)
@@ -524,6 +532,10 @@ class TestEngineViewController: BaseQuestionsPageViewController {
     }
     
     func onPressStopButton() {
+        if exam == nil {
+            showEndExamDialog()
+            return
+        }
         alertDialog = UIAlertController(
             title: Strings.EXIT_EXAM,
             message: Strings.END_MESSAGE,
@@ -553,6 +565,25 @@ class TestEngineViewController: BaseQuestionsPageViewController {
                 }
             ))
         }
+        alertDialog.addAction(UIAlertAction(
+            title: Strings.CANCEL,
+            style: UIAlertAction.Style.cancel
+        ))
+        present(alertDialog, animated: true, completion: nil)
+    }
+
+    func showEndExamDialog() {
+        alertDialog = UIAlertController(
+            title: Strings.EXIT_EXAM,
+            message: "Are you sure? Want to end the exam",
+            preferredStyle: UIUtils.getActionSheetStyle()
+        )
+        alertDialog.addAction(UIAlertAction(
+            title: Strings.END, style: UIAlertAction.Style.destructive,
+            handler: { (action: UIAlertAction!) in
+                self.onClickEnd()
+            }
+        ))
         alertDialog.addAction(UIAlertAction(
             title: Strings.CANCEL,
             style: UIAlertAction.Style.cancel
@@ -609,7 +640,7 @@ class TestEngineViewController: BaseQuestionsPageViewController {
 extension TestEngineViewController: QuestionsPageViewDelegate {
     
     func questionsDidLoad() {
-        if sections.count <= 1 && exam.templateType == 2 || unlockedSectionExam {
+        if sections.count <= 1 && exam != nil && (exam!.templateType == 2 || unlockedSectionExam) {
             // Used to get items in order as it fetched
             var spinnerItemsList = [String]()
             var groupedAttemptItems = OrderedDictionary<String, [AttemptItem]>()

--- a/ios-app/UI/TestEngineViewController.swift
+++ b/ios-app/UI/TestEngineViewController.swift
@@ -109,7 +109,7 @@ class TestEngineViewController: BaseQuestionsPageViewController {
             setUpDropDownForSections()
         }
     }
-
+    
     private func setUpDropDownForLockedSections() {
         plainDropDown = PlainDropDown(containerView: dropdownContainer)
         plainDropDown.dropDown.selectionBackgroundColor = UIColor.clear
@@ -118,7 +118,7 @@ class TestEngineViewController: BaseQuestionsPageViewController {
         
         plainDropDown.dropDown.customCellConfiguration = {
             (index: Index, item: String, cell: DropDownCell) -> Void in
-
+            
             let cell = cell as! LockableSectionDropDownCell
             let selectedItemIndex = self.plainDropDown.dropDown.indexForSelectedRow
             cell.initCell(index: index, sectionName: item, selectedItem: selectedItemIndex!)

--- a/ios-app/UI/TrophiesAchievedViewController.swift
+++ b/ios-app/UI/TrophiesAchievedViewController.swift
@@ -36,7 +36,7 @@ class TrophiesAchievedViewController: UIViewController {
     @IBOutlet weak var okayButton: UIButton!
     @IBOutlet weak var trophyImageLayout: UIView!
     
-    var exam: Exam!
+    var exam: Exam?
     var contentAttempt: ContentAttempt!
     
     override func viewDidLoad() {


### PR DESCRIPTION
- The custom test generation feature does not have an exam object but we need to take the exam in mobile template.
- So in this commit, we made the mobile exam template work without the exam object.