### PR TITLE
fix: Unable to Close WebView Controller without Back Stack

### DIFF
--- a/ios-app/UI/WebViewController.swift
+++ b/ios-app/UI/WebViewController.swift
@@ -107,10 +107,8 @@ class WebViewController: BaseWebViewController, WKWebViewDelegate {
     }
     
     @objc func goBack() {
-        if (useWebviewNavigation) {
-            if (webView.canGoBack) {
-                webView.goBack()
-            }
+        if (useWebviewNavigation && webView.canGoBack) {
+            webView.goBack()
         } else {
             self.cleanAllCookies()
             self.dismiss(animated: true, completion: nil)


### PR DESCRIPTION
- If webview does not have back stack we cant close the webview viewcontroller
- In this commit, we fix this issue if webview dont have back stack we will close webview viewcontroller