### PR TITLE
refactor: Add support for storing and fetching exam questions from the database using the attemptId

### DIFF
--- a/ios-app/AppDelegate.swift
+++ b/ios-app/AppDelegate.swift
@@ -116,7 +116,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             SentrySDK.setUser(user)
         }
         
-        let config = Realm.Configuration(schemaVersion: 30)
+        let config = Realm.Configuration(schemaVersion: 31)
         Realm.Configuration.defaultConfiguration = config
         let viewController:UIViewController
         

--- a/ios-app/Model/ExamQuestion.swift
+++ b/ios-app/Model/ExamQuestion.swift
@@ -13,6 +13,7 @@ class ExamQuestion: DBModel {
     @objc dynamic var negativeMarks = ""
     @objc dynamic var order = -1
     @objc dynamic var examId = 8989
+    @objc dynamic var attemptId = -1
     @objc dynamic var question: AttemptQuestion? = nil
     @objc dynamic var questionId: Int = -1
     
@@ -22,6 +23,7 @@ class ExamQuestion: DBModel {
         negativeMarks <- map["negative_marks"]
         order <- map["order"]
         examId <- map["exam_id"]
+        attemptId <- map["attempt_id"]
         questionId <- map["question_id"]
     }
     

--- a/ios-app/Repository/AttemptRepository.swift
+++ b/ios-app/Repository/AttemptRepository.swift
@@ -12,9 +12,9 @@ class AttemptRepository {
     func loadAttempt(attemptsUrl: String, completion: @escaping(ContentAttempt?, TPError?) -> Void) {
         TPApiClient.request(type: ContentAttempt.self, endpointProvider: TPEndpointProvider(.post, url: attemptsUrl), completion: completion)
     }
-    
+
     func loadQuestions(url: String, examId: Int, attemptId: Int, completion: @escaping([AttemptItem]?, TPError?) -> Void) {
-        let examQuestions = getExamquestionsFromDB(examId: examId)
+        let examQuestions = getExamquestionsFromDB(examId: examId, attemptId: attemptId)
         if (!examQuestions.isEmpty) {
             var attemptItems: [AttemptItem]
             if (getAttemtItems(attemptId: attemptId).isEmpty) {
@@ -33,23 +33,30 @@ class AttemptRepository {
     func fetchQuestions(url: String, attemptId: Int, examId: Int, completion: (([AttemptItem]?, TPError?) -> Void)?) {
         
         TPApiClient.request(type: ApiResponse<ExamQuestionsResponse>.self, endpointProvider: TPEndpointProvider(.get, url: url), completion:  { response, error in
-            self.storeInDB(examQuestions: response?.results.parse() ?? [])
-
+            self.storeInDB(examQuestions: response?.results.parse() ?? [],examId: examId, attemptId: attemptId)
             if (response?.next != nil && response?.next.isEmpty == false) {
                 self.fetchQuestions(url: response!.next, attemptId: attemptId, examId: examId, completion: completion)
             } else if (completion != nil) {
-                let examQuestions = self.getExamquestionsFromDB(examId: examId)
+                let examQuestions = self.getExamquestionsFromDB(examId: examId, attemptId: attemptId)
                 let attemptItems = self.createAttemptItems(examQuestions: examQuestions, attemptId: attemptId)
                 completion?(attemptItems, error)
             }
             
         })
     }
-    func getExamquestionsFromDB(examId: Int) -> [ExamQuestion] {
-        return DBManager<ExamQuestion>().getItemsFromDB(filteredBy: "examId=\(examId)", byKeyPath: "order")
+    func getExamquestionsFromDB(examId: Int, attemptId: Int) -> [ExamQuestion] {
+        if examId == -1 {
+            return DBManager<ExamQuestion>().getItemsFromDB(filteredBy: "attemptId=\(attemptId)", byKeyPath: "order")
+        } else {
+            return DBManager<ExamQuestion>().getItemsFromDB(filteredBy: "examId=\(examId)", byKeyPath: "order")
+        }
     }
     
-    func storeInDB(examQuestions: [ExamQuestion]) {
+    func storeInDB(examQuestions: [ExamQuestion], examId: Int, attemptId: Int) {
+        for question in examQuestions {
+                question.examId = examId
+                question.attemptId = attemptId
+            }
         DBManager<ExamQuestion>().addData(objects: examQuestions)
     }
     


### PR DESCRIPTION
- Added field `attemptId` in ExamQuestion model
- Previously we stored exam questions with examId
- Now we don't have an exam object for the custom test generation exam so we save the exam questions with attemptId and examId as null
- In this commit, we have implemented logic to retrieve a question from the database. If an examId is provided, we fetch the question associated with that examId; otherwise, we fetch the question using the attemptId.