### PR TITLE
fix: Add exam timer for custom test

### DIFF
--- a/ios-app/UI/CustomTestGenerationViewController.swift
+++ b/ios-app/UI/CustomTestGenerationViewController.swift
@@ -9,6 +9,9 @@
 import Foundation
 import WebKit
 
+let DEFAULT_EXAM_TIME = "24:00:00"
+let INFINITE_EXAM_TIME = "24:00:00"
+
 class CustomTestGenerationViewController: WebViewController, WKScriptMessageHandler {
     
     override func viewDidLoad() {
@@ -58,11 +61,10 @@ class CustomTestGenerationViewController: WebViewController, WKScriptMessageHand
                     self.showErrorMessage(error: error)
                     return
                 }
-                // Check if the remaining time for the attempt is "0:00:00" that's indicating infinite time.
-                // If the remaining time is infinite, set it to a default value of 24 hours.
+                // Check if the remaining time for the attempt is infinite we reset to default value of 24 hours.
                 // This is done because our app doesn't support exams with infinite timing.
-                if attempt?.remainingTime == "0:00:00" {
-                    attempt?.remainingTime = "24:00:00"
+                if attempt?.remainingTime == INFINITE_EXAM_TIME {
+                    attempt?.remainingTime = DEFAULT_EXAM_TIME
                 }
                 
                 if quizMode {

--- a/ios-app/UI/CustomTestGenerationViewController.swift
+++ b/ios-app/UI/CustomTestGenerationViewController.swift
@@ -10,7 +10,7 @@ import Foundation
 import WebKit
 
 let DEFAULT_EXAM_TIME = "24:00:00"
-let INFINITE_EXAM_TIME = "24:00:00"
+let INFINITE_EXAM_TIME = "0:00:00"
 
 class CustomTestGenerationViewController: WebViewController, WKScriptMessageHandler {
     

--- a/ios-app/UI/CustomTestGenerationViewController.swift
+++ b/ios-app/UI/CustomTestGenerationViewController.swift
@@ -58,8 +58,9 @@ class CustomTestGenerationViewController: WebViewController, WKScriptMessageHand
                     self.showErrorMessage(error: error)
                     return
                 }
-                // If the attempt has 0:00:00 remaining time, it means infinite timing.
-                // Since our app doesn't support exams with infinite timing, we set the remaining time to 24 hours.
+                // Check if the remaining time for the attempt is "0:00:00" that's indicating infinite time.
+                // If the remaining time is infinite, set it to a default value of 24 hours.
+                // This is done because our app doesn't support exams with infinite timing.
                 if attempt?.remainingTime == "0:00:00" {
                     attempt?.remainingTime = "24:00:00"
                 }

--- a/ios-app/UI/CustomTestGenerationViewController.swift
+++ b/ios-app/UI/CustomTestGenerationViewController.swift
@@ -58,11 +58,11 @@ class CustomTestGenerationViewController: WebViewController, WKScriptMessageHand
                     self.showErrorMessage(error: error)
                     return
                 }
-                
-                // Attempt we are receiving here does not contain remaining time because its
-                // infinite timing exam attempt. As our app doesn't support exams with infinite
-                // timing, so we are set 24 hours for remainingTime in this attempt.
-                attempt?.remainingTime = "24:00:00"
+                // If the attempt has 0:00:00 remaining time, it means infinite timing.
+                // Since our app doesn't support exams with infinite timing, we set the remaining time to 24 hours.
+                if attempt?.remainingTime == "0:00:00" {
+                    attempt?.remainingTime = "24:00:00"
+                }
                 
                 if quizMode {
                     self.goToQuizExam(attempt!)

--- a/ios-app/UI/TestEngineViewController.swift
+++ b/ios-app/UI/TestEngineViewController.swift
@@ -81,7 +81,7 @@ class TestEngineViewController: BaseQuestionsPageViewController {
     }
     
     private func showOrHideTimer(){
-        if(exam == nil) {
+        if(exam == nil && attempt?.remainingTime == "24:00:00") {
             parentSlidingViewController.remainingTimeLabel.isHidden = true
         }
     }

--- a/ios-app/UI/TestEngineViewController.swift
+++ b/ios-app/UI/TestEngineViewController.swift
@@ -81,7 +81,7 @@ class TestEngineViewController: BaseQuestionsPageViewController {
     }
     
     private func showOrHideTimer(){
-        if(exam == nil && attempt?.remainingTime == "24:00:00") {
+        if(exam == nil && attempt?.remainingTime == DEFAULT_EXAM_TIME) {
             parentSlidingViewController.remainingTimeLabel.isHidden = true
         }
     }


### PR DESCRIPTION
- Initially, The exam timer is not available for custom tests because it has infinite time.
- In this commit, we have introduced an exam time limit for custom tests. If the user selects a specific time, the exam timer will be displayed; otherwise, it remains hidden.