### PR TITLE
feat: Add support take exams in quiz mode or regular mode

### DIFF
--- a/ios-app/AppDelegate.swift
+++ b/ios-app/AppDelegate.swift
@@ -116,7 +116,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             SentrySDK.setUser(user)
         }
         
-        let config = Realm.Configuration(schemaVersion: 31)
+        let config = Realm.Configuration(schemaVersion: 32)
         Realm.Configuration.defaultConfiguration = config
         let viewController:UIViewController
         

--- a/ios-app/Model/Attempt.swift
+++ b/ios-app/Model/Attempt.swift
@@ -51,6 +51,7 @@ class Attempt: DBModel {
     @objc var speed: Int = 0
     @objc var accuracy: Int = 0
     @objc var exam: Int = -1
+    @objc var attemptType: Int = 0
     var sections = List<AttemptSection>()
     
 
@@ -80,6 +81,7 @@ class Attempt: DBModel {
         speed <- map["speed"]
         accuracy <- map["accuracy"]
         exam <- map["exam"]
+        attemptType <- map["attempt_type"]
         sections <- (map["sections"], ListTransform<AttemptSection>())
     }
 

--- a/ios-app/Model/Exam.swift
+++ b/ios-app/Model/Exam.swift
@@ -61,6 +61,7 @@ class Exam: DBModel {
     @objc dynamic var isGrowthHackEnabled: Bool = false;
     @objc dynamic var shareTextForSolutionUnlock: String = "";
     @objc dynamic var showAnalytics: Bool = false
+    @objc dynamic var enableQuizMode: Bool = false;
     
     override public static func primaryKey() -> String? {
         return "id"
@@ -104,6 +105,7 @@ class Exam: DBModel {
         shareTextForSolutionUnlock <- map["share_text_for_solution_unlock"]
         examDescription <- map["description"]
         showAnalytics <- map["show_analytics"]
+        enableQuizMode <- map["enable_quiz_mode"]
     }
     
     func hasStarted() -> Bool {

--- a/ios-app/UI/StartExamScreenViewController.swift
+++ b/ios-app/UI/StartExamScreenViewController.swift
@@ -124,15 +124,15 @@ class StartExamScreenViewController: UIViewController {
     
     private func showExamModePopUp(_ sender: UIButton) {
         let actionSheet = UIAlertController(title: "Select Exam Mode", message: nil, preferredStyle: .actionSheet)
-        let option1 = UIAlertAction(title: "Regular Mode", style: .default) { _ in
+        let regularModeButton = UIAlertAction(title: "Regular Mode", style: .default) { _ in
             self.startExam(StartExamScreenViewController.REGULAR_ATTEMPT)
         }
-        let option2 = UIAlertAction(title: "Quiz Mode", style: .default) { _ in
+        let quizModeButton = UIAlertAction(title: "Quiz Mode", style: .default) { _ in
             self.startExam(StartExamScreenViewController.QUIZ_ATTEMPT)
         }
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
-        actionSheet.addAction(option1)
-        actionSheet.addAction(option2)
+        actionSheet.addAction(regularModeButton)
+        actionSheet.addAction(quizModeButton)
         actionSheet.addAction(cancelAction)
         if let popoverController = actionSheet.popoverPresentationController {
             popoverController.sourceView = sender

--- a/ios-app/UI/StartExamScreenViewController.swift
+++ b/ios-app/UI/StartExamScreenViewController.swift
@@ -108,6 +108,33 @@ class StartExamScreenViewController: UIViewController {
     }
     
     @IBAction func startExam(_ sender: UIButton) {
+        if(exam.enableQuizMode) {
+            showExamModePopUp(sender)
+        } else {
+            startExam()
+        }
+    }
+    
+    private func showExamModePopUp(_ sender: UIButton) {
+        let actionSheet = UIAlertController(title: "Select Exam Mode", message: nil, preferredStyle: .actionSheet)
+        let option1 = UIAlertAction(title: "Regular Mode", style: .default) { _ in
+            self.startExam()
+        }
+        let option2 = UIAlertAction(title: "Quiz Mode", style: .default) { _ in
+            self.startExam()
+        }
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
+        actionSheet.addAction(option1)
+        actionSheet.addAction(option2)
+        actionSheet.addAction(cancelAction)
+        if let popoverController = actionSheet.popoverPresentationController {
+            popoverController.sourceView = sender
+            popoverController.permittedArrowDirections = [.up, .down]
+        }
+        present(actionSheet, animated: true, completion: nil)
+    }
+    
+    func startExam() {
         present(alertController, animated: false, completion: nil)
         startButton.isHidden = true
         startAttempt()

--- a/ios-app/UI/StartExamScreenViewController.swift
+++ b/ios-app/UI/StartExamScreenViewController.swift
@@ -28,6 +28,9 @@ import UIKit
 import RealmSwift
 
 class StartExamScreenViewController: UIViewController {
+    
+    static let REGULAR_ATTEMPT = 0
+    static let QUIZ_ATTEMPT = 1
 
     @IBOutlet weak var examTitle: UILabel!
     @IBOutlet weak var questionsCount: UILabel!
@@ -109,23 +112,23 @@ class StartExamScreenViewController: UIViewController {
     
     @IBAction func startExam(_ sender: UIButton) {
         if (contentAttempt?.assessment?.state == "Running"){
-            startExam(contentAttempt?.assessment?.attemptType ?? 0)
+            startExam(contentAttempt?.assessment?.attemptType ?? StartExamScreenViewController.REGULAR_ATTEMPT)
             return
         }
         if(exam.enableQuizMode) {
             showExamModePopUp(sender)
         } else {
-            startExam(0)
+            startExam(StartExamScreenViewController.REGULAR_ATTEMPT)
         }
     }
     
     private func showExamModePopUp(_ sender: UIButton) {
         let actionSheet = UIAlertController(title: "Select Exam Mode", message: nil, preferredStyle: .actionSheet)
         let option1 = UIAlertAction(title: "Regular Mode", style: .default) { _ in
-            self.startExam(0)
+            self.startExam(StartExamScreenViewController.REGULAR_ATTEMPT)
         }
         let option2 = UIAlertAction(title: "Quiz Mode", style: .default) { _ in
-            self.startExam(1)
+            self.startExam(StartExamScreenViewController.QUIZ_ATTEMPT)
         }
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
         actionSheet.addAction(option1)
@@ -215,7 +218,7 @@ class StartExamScreenViewController: UIViewController {
                 } else {
                     self.attempt = attempt as? Attempt
                 }
-                if (self.attempt?.attemptType == 1){
+                if (self.attempt?.attemptType == StartExamScreenViewController.QUIZ_ATTEMPT){
                     self.goToQuizExam()
                 } else {
                     self.gotoTestEngine()


### PR DESCRIPTION
- We implemented a popup in this commit to allow users to select their preferred exam mode when starting an exam.
- When a user pauses an exam and later resumes it, we utilize the `attemptType` field to determine which mode the exam was originally started in. Based on this information, we appropriately resume the exam accordingly.