### PR TITLE
fix: Show total time in TestReport page

### DIFF
--- a/ios-app/UI/TestReportViewController.swift
+++ b/ios-app/UI/TestReportViewController.swift
@@ -25,7 +25,6 @@
 
 import UIKit
 import RealmSwift
-import Foundation
 
 class TestReportViewController: UIViewController {
 

--- a/ios-app/UI/TestReportViewController.swift
+++ b/ios-app/UI/TestReportViewController.swift
@@ -25,6 +25,7 @@
 
 import UIKit
 import RealmSwift
+import Foundation
 
 class TestReportViewController: UIViewController {
 
@@ -85,7 +86,7 @@ class TestReportViewController: UIViewController {
         examTitle.text = exam?.title ?? "Custom Module"
         totalQuestions.text = String(exam?.numberOfQuestions ?? attempt.totalQuestions)
         totalMarks.text = exam?.totalMarks ?? ""
-        totalTime.text = exam?.duration ?? ""
+        totalTime.text = getTotalTime()
         cutoff.text = String(exam?.passPercentage ?? 0.0)
         percentage.text = attempt.percentage
         correct.text = String(attempt!.correctCount)
@@ -145,6 +146,24 @@ class TestReportViewController: UIViewController {
         } else {
             solutionButtonLayout.isHidden = false
         }
+    }
+    
+    private func getTotalTime() -> String {
+        if (exam != nil){
+            return exam?.totalMarks ?? ""
+        } else if (attempt?.remainingTime == INFINITE_EXAM_TIME) {
+            return ""
+        } else {
+            return addTimeStrings(attempt?.timeTaken ?? INFINITE_EXAM_TIME, attempt?.remainingTime ?? INFINITE_EXAM_TIME)
+        }
+    }
+    
+    func addTimeStrings(_ timeTaken: String,_ remainingTime: String) -> String {
+        let totalTime = timeTaken.secondsFromString + remainingTime.secondsFromString + 1
+        let hours = (totalTime / (60 * 60)) % 12
+        let minutes = (totalTime / 60) % 60
+        let seconds = totalTime % 60
+        return String(format: "%d:%02d:%02d", hours, minutes, seconds)
     }
 
     @IBAction func showShareScreen(_ sender: Any) {

--- a/ios-app/UI/TestReportViewController.swift
+++ b/ios-app/UI/TestReportViewController.swift
@@ -149,20 +149,12 @@ class TestReportViewController: UIViewController {
     
     private func getTotalTime() -> String {
         if (exam != nil){
-            return exam?.totalMarks ?? ""
+            return exam?.duration ?? ""
         } else if (attempt?.remainingTime == INFINITE_EXAM_TIME) {
             return ""
         } else {
-            return addTimeStrings(attempt?.timeTaken ?? INFINITE_EXAM_TIME, attempt?.remainingTime ?? INFINITE_EXAM_TIME)
+            return TimeUtils.addTimeStrings(attempt?.timeTaken, attempt?.remainingTime)
         }
-    }
-    
-    func addTimeStrings(_ timeTaken: String,_ remainingTime: String) -> String {
-        let totalTime = timeTaken.secondsFromString + remainingTime.secondsFromString + 1
-        let hours = (totalTime / (60 * 60)) % 12
-        let minutes = (totalTime / 60) % 60
-        let seconds = totalTime % 60
-        return String(format: "%d:%02d:%02d", hours, minutes, seconds)
     }
 
     @IBAction func showShareScreen(_ sender: Any) {

--- a/ios-app/Utils/TimeUtils.swift
+++ b/ios-app/Utils/TimeUtils.swift
@@ -18,5 +18,14 @@ public class TimeUtils {
         
         return seconds
     }
+    
+    static func addTimeStrings(_ timeTaken: String?,_ remainingTime: String?) -> String {
+        // Here, we add one second to totalTime because remainingTime is always one second less than the actual value.
+        let totalTime = (timeTaken?.secondsFromString ?? 0) + (remainingTime?.secondsFromString ?? 0) + 1
+        let hours = (totalTime / (60 * 60)) % 12
+        let minutes = (totalTime / 60) % 60
+        let seconds = totalTime % 60
+        return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+    }
 }
 


### PR DESCRIPTION
- In this commit (dde8e6f), a timer for a custom test has been added. When the user finishes the exam, the report page is displayed without showing the total time.
- In this commit, we showcase the total time on the report page by adding both the `timeTaken` and `remainingTime` values in attempt.