### PR TITLE
enhancement: Update the quiz question fetching API to version 2.5

### DIFF
--- a/ios-app/ViewModel/QuizExamViewModel.swift
+++ b/ios-app/ViewModel/QuizExamViewModel.swift
@@ -63,7 +63,8 @@ extension QuizExamViewModel {
     }
     
     public func loadQuestions(attemptId: Int, completion: @escaping([AttemptItem]?, TPError?) -> Void) {
-        repository.loadQuestions(url: exam.getQuestionsURL(), examId: exam.id, attemptId: attemptId, completion: completion)
+        let questionUrl = Constants.BASE_URL + "/api/v2.5/attempts/\(attemptId)/questions/"
+        repository.loadQuestions(url: questionUrl, examId: exam.id, attemptId: attemptId, completion: completion)
     }
     
 }


### PR DESCRIPTION
- Previously, we fetched quiz exam questions using the `examId` in version 2.4.
- Hereafter, we will fetch the quiz exam questions using the `attemptId` in version 2.5.