### PR TITLE
fix: Add `selectedLanguage` and `languages` fields in Exam model

### DIFF
--- a/ios-app/AppDelegate.swift
+++ b/ios-app/AppDelegate.swift
@@ -116,7 +116,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             SentrySDK.setUser(user)
         }
         
-        let config = Realm.Configuration(schemaVersion: 33)
+        let config = Realm.Configuration(schemaVersion: 34)
         Realm.Configuration.defaultConfiguration = config
         let viewController:UIViewController
         

--- a/ios-app/Model/Exam.swift
+++ b/ios-app/Model/Exam.swift
@@ -24,6 +24,7 @@
 //
 
 import ObjectMapper
+import RealmSwift
 
 class Exam: DBModel {
     @objc dynamic var url: String = "";
@@ -63,7 +64,7 @@ class Exam: DBModel {
     @objc dynamic var showAnalytics: Bool = false
     @objc dynamic var enableQuizMode: Bool = false;
     @objc dynamic var selectedLanguage: Language?
-    @objc dynamic var languages: [Language]?
+    var languages = List<Language>()
     
     override public static func primaryKey() -> String? {
         return "id"
@@ -109,7 +110,7 @@ class Exam: DBModel {
         showAnalytics <- map["show_analytics"]
         enableQuizMode <- map["enable_quiz_mode"]
         selectedLanguage <- map["selected_language"]
-        languages <- map["languages"]
+        languages <- (map["languages"], ListTransform<Language>())
     }
     
     func hasStarted() -> Bool {

--- a/ios-app/Model/Exam.swift
+++ b/ios-app/Model/Exam.swift
@@ -62,6 +62,8 @@ class Exam: DBModel {
     @objc dynamic var shareTextForSolutionUnlock: String = "";
     @objc dynamic var showAnalytics: Bool = false
     @objc dynamic var enableQuizMode: Bool = false;
+    @objc dynamic var selectedLanguage: Language?
+    @objc dynamic var languages: [Language]
     
     override public static func primaryKey() -> String? {
         return "id"
@@ -106,6 +108,8 @@ class Exam: DBModel {
         examDescription <- map["description"]
         showAnalytics <- map["show_analytics"]
         enableQuizMode <- map["enable_quiz_mode"]
+        selectedLanguage <- map["selected_language"]
+        languages <- map["languages"]
     }
     
     func hasStarted() -> Bool {

--- a/ios-app/Model/Exam.swift
+++ b/ios-app/Model/Exam.swift
@@ -63,7 +63,7 @@ class Exam: DBModel {
     @objc dynamic var showAnalytics: Bool = false
     @objc dynamic var enableQuizMode: Bool = false;
     @objc dynamic var selectedLanguage: Language?
-    @objc dynamic var languages: [Language]
+    @objc dynamic var languages: [Language]?
     
     override public static func primaryKey() -> String? {
         return "id"


### PR DESCRIPTION
- This commit introduces the `selectedLanguage` and `languages` fields to the Exam.
- The `selectedLanguage` field indicates the language in which the user is taking the exam.
- The `languages` field provides a list of languages available for the exam.