### PR TITLE
fix: Close Custom test view controller when user press the back button

### DIFF
--- a/ios-app/UI/CustomTestGenerationViewController.swift
+++ b/ios-app/UI/CustomTestGenerationViewController.swift
@@ -132,6 +132,9 @@ class CustomTestGenerationViewController: WebViewController, WKScriptMessageHand
     override func onFinishLoadingWebView() {
         activityIndicator?.stopAnimating()
     }
-            
-    
+
+    override func goBack() {
+        self.cleanAllCookies()
+        self.dismiss(animated: true, completion: nil)
+    }
 }

--- a/ios-app/UI/TestReportViewController.swift
+++ b/ios-app/UI/TestReportViewController.swift
@@ -268,7 +268,9 @@ class TestReportViewController: UIViewController {
     
     func goToCourseListView() {
         let customTestViewController = self.presentingViewController as? CustomTestGenerationViewController
-        customTestViewController?.presentingViewController?.dismiss(animated: true, completion: nil)
+        customTestViewController?.dismiss(animated: true, completion: {
+            customTestViewController?.onFinishLoadingWebView()
+        })
     }
 
     func goToContentDetailPageViewController(_ contentDetailPageViewController: UIViewController) {

--- a/ios-app/UI/TestReportViewController.swift
+++ b/ios-app/UI/TestReportViewController.swift
@@ -268,9 +268,7 @@ class TestReportViewController: UIViewController {
     
     func goToCourseListView() {
         let customTestViewController = self.presentingViewController as? CustomTestGenerationViewController
-        customTestViewController?.dismiss(animated: true, completion: {
-            customTestViewController?.onFinishLoadingWebView()
-        })
+        customTestViewController?.presentingViewController?.dismiss(animated: true, completion: nil)
     }
 
     func goToContentDetailPageViewController(_ contentDetailPageViewController: UIViewController) {


### PR DESCRIPTION
- Previously when pressing the back button we navigated between the webview if it have a back stack.
- In this commit, the custom test view controller is closed when the user presses the back button.