### PR TITLE
fix: Prevent Custom test view controller closing

### DIFF
--- a/ios-app/UI/TestReportViewController.swift
+++ b/ios-app/UI/TestReportViewController.swift
@@ -268,7 +268,9 @@ class TestReportViewController: UIViewController {
     
     func goToCourseListView() {
         let customTestViewController = self.presentingViewController as? CustomTestGenerationViewController
-        customTestViewController?.presentingViewController?.dismiss(animated: true, completion: nil)
+        customTestViewController?.dismiss(animated: true, completion: {
+            customTestViewController?.onFinishLoadingWebView()
+        })
     }
 
     func goToContentDetailPageViewController(_ contentDetailPageViewController: UIViewController) {


### PR DESCRIPTION
- Previously, when the user closed the test report view controller we closed the custom test view controller too.
- With this commit, we no longer close the custom test view controller.