### PR TITLE
fix: Hide language switching button in custom test

### DIFF
--- a/ios-app/UI/TestEngineSlidingViewController.swift
+++ b/ios-app/UI/TestEngineSlidingViewController.swift
@@ -63,6 +63,6 @@ class TestEngineSlidingViewController: BaseQuestionsSlidingViewController {
     }
     
     func showOrHideLanguageButton() {
-        languagefilter.isHidden = !(self.exam?.hasMultipleLanguages() ?? true)
+        languagefilter.isHidden = !(self.exam?.hasMultipleLanguages() ?? false)
     }
 }


### PR DESCRIPTION
- In this commit 05fc91e we added a language-switching option to exams.
- However, for custom test generation, there is no support for multiple languages. Therefore, we hide the language-switching button when the user takes a custom test.