### PR TITLE
fix: Not able to close the Test report view controller

### DIFF
--- a/ios-app/UI/TestReportViewController.swift
+++ b/ios-app/UI/TestReportViewController.swift
@@ -263,7 +263,7 @@ class TestReportViewController: UIViewController {
     
     func isPresentedFromCustomTestViewController() -> Bool {
         let customTestViewController = self.presentingViewController as? CustomTestGenerationViewController
-        return customTestViewController is CustomTestGenerationViewController?
+        return customTestViewController != nil
     }
     
     func goToCourseListView() {


### PR DESCRIPTION
- When the user completes the custom test, we present the test report view controller.
- The inability to close the test report view controller because of the absence of a null check for presentingViewController.