### PR TITLE
fix: App crash on open large pdf

### DIFF
--- a/ios-app.xcodeproj/project.pbxproj
+++ b/ios-app.xcodeproj/project.pbxproj
@@ -357,6 +357,7 @@
 		8CF6972D232652A80040A986 /* Stackview+BackgroundColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF6972C232652A80040A986 /* Stackview+BackgroundColor.swift */; };
 		D907E7A92B19D11C00BEA874 /* Language.swift in Sources */ = {isa = PBXBuildFile; fileRef = D907E7A82B19D11C00BEA874 /* Language.swift */; };
 		D9151E7F2A7B8A9C00EAE2DF /* CustomTestGenerationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9151E7E2A7B8A9C00EAE2DF /* CustomTestGenerationViewController.swift */; };
+		D9533ABE2B99CD2700E73A78 /* PDFViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9533ABD2B99CD2700E73A78 /* PDFViewController.swift */; };
 		D98010692B035E780071C397 /* CustomTestQuizExamViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D98010682B035E780071C397 /* CustomTestQuizExamViewModel.swift */; };
 		D990C7EE2B316C6300B3ED4D /* AttemptAnswerTranslation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D990C7ED2B316C6300B3ED4D /* AttemptAnswerTranslation.swift */; };
 		D990C7F02B31731300B3ED4D /* AttemptQuestionTranslation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D990C7EF2B31731300B3ED4D /* AttemptQuestionTranslation.swift */; };
@@ -817,6 +818,7 @@
 		9B482AA21F7CADEABC2BF009 /* ios_appTests-ios_appMocks.generated.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = "ios_appTests-ios_appMocks.generated.swift"; path = "MockingbirdMocks/ios_appTests-ios_appMocks.generated.swift"; sourceTree = "<group>"; };
 		D907E7A82B19D11C00BEA874 /* Language.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Language.swift; path = "ios-app/Model/Language.swift"; sourceTree = SOURCE_ROOT; };
 		D9151E7E2A7B8A9C00EAE2DF /* CustomTestGenerationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTestGenerationViewController.swift; sourceTree = "<group>"; };
+		D9533ABD2B99CD2700E73A78 /* PDFViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFViewController.swift; sourceTree = "<group>"; };
 		D98010682B035E780071C397 /* CustomTestQuizExamViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTestQuizExamViewModel.swift; sourceTree = "<group>"; };
 		D990C7ED2B316C6300B3ED4D /* AttemptAnswerTranslation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttemptAnswerTranslation.swift; sourceTree = "<group>"; };
 		D990C7EF2B31731300B3ED4D /* AttemptQuestionTranslation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttemptQuestionTranslation.swift; sourceTree = "<group>"; };
@@ -940,6 +942,7 @@
 			children = (
 				25E435DF263ADD4800243FD3 /* CarouselCellViews */,
 				25E435D8263ADC9200243FD3 /* SectionControllers */,
+				D9533ABD2B99CD2700E73A78 /* PDFViewController.swift */,
 			);
 			path = Dashboard;
 			sourceTree = "<group>";
@@ -1786,6 +1789,7 @@
 				2F48C80D1FD28902009C686C /* PostTableViewCell.swift in Sources */,
 				25705017246E48BA00E6C688 /* ListTransform.swift in Sources */,
 				2F9699781FC2A202001B2B18 /* ContentsTableViewController.swift in Sources */,
+				D9533ABE2B99CD2700E73A78 /* PDFViewController.swift in Sources */,
 				258036A52743AA2400397639 /* DRMKeySessionDelegate.swift in Sources */,
 				2F25D560201F085A00C01CCE /* LeaderboardTableViewCell.swift in Sources */,
 				2F48C8031FCE9A37009C686C /* CommentPager.swift in Sources */,

--- a/ios-app/Base.lproj/ChapterContent.storyboard
+++ b/ios-app/Base.lproj/ChapterContent.storyboard
@@ -2256,6 +2256,36 @@
             </objects>
             <point key="canvasLocation" x="4607" y="-603"/>
         </scene>
+        <!--View Controller-->
+        <scene sceneID="8GU-P4-0us">
+            <objects>
+                <viewController storyboardIdentifier="PDFViewController" id="2dF-1v-giC" customClass="PDFViewController" customModule="ios_app" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="KcC-IT-yl3">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OOB-Xs-tz3" customClass="PDFView">
+                                <rect key="frame" x="0.0" y="48" width="414" height="800"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            </view>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="Ccu-ap-YYO"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="OOB-Xs-tz3" firstAttribute="leading" secondItem="Ccu-ap-YYO" secondAttribute="leading" id="7kx-eC-YLj"/>
+                            <constraint firstItem="OOB-Xs-tz3" firstAttribute="top" secondItem="Ccu-ap-YYO" secondAttribute="top" id="Gj6-AJ-21m"/>
+                            <constraint firstItem="OOB-Xs-tz3" firstAttribute="centerY" secondItem="KcC-IT-yl3" secondAttribute="centerY" id="WII-lH-DYE"/>
+                            <constraint firstItem="OOB-Xs-tz3" firstAttribute="centerX" secondItem="KcC-IT-yl3" secondAttribute="centerX" id="Z9F-Kg-pve"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="pdfView" destination="OOB-Xs-tz3" id="g3S-0l-dPy"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="rqo-5A-lDw" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4107.2463768115949" y="171.42857142857142"/>
+        </scene>
     </scenes>
     <designables>
         <designable name="gc5-34-E3A">
@@ -2272,7 +2302,7 @@
         <image name="ic_navigate_before_36pt" width="36" height="36"/>
         <image name="ic_navigate_next" width="24" height="24"/>
         <image name="ic_thumb_up_18pt" width="18" height="18"/>
-        <image name="language_icon" width="128" height="128"/>
+        <image name="language_icon" width="20" height="20"/>
         <image name="lock_outline" width="10" height="16"/>
         <image name="move_bookmark" width="12" height="15"/>
         <image name="questions_outline_16pt" width="16" height="16"/>

--- a/ios-app/Base.lproj/ChapterContent.storyboard
+++ b/ios-app/Base.lproj/ChapterContent.storyboard
@@ -2254,7 +2254,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="xBC-E7-d8K" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4607" y="-603"/>
+            <point key="canvasLocation" x="4605.7971014492759" y="-603.34821428571422"/>
         </scene>
         <!--View Controller-->
         <scene sceneID="8GU-P4-0us">
@@ -2264,27 +2264,43 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OOB-Xs-tz3" customClass="PDFView">
-                                <rect key="frame" x="0.0" y="48" width="414" height="800"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Eo7-Aq-G9x" userLabel="PDFView" customClass="PDFView">
+                                <rect key="frame" x="0.0" y="92" width="414" height="770"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
+                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qE2-0Y-rq0">
+                                <rect key="frame" x="0.0" y="48" width="414" height="44"/>
+                                <items>
+                                    <navigationItem title="Title" id="lt4-aO-HLK" userLabel="Navigation Bar Item">
+                                        <barButtonItem key="leftBarButtonItem" image="ic_navigate_before_36pt" style="done" id="hXJ-1N-HD6" userLabel="Back">
+                                            <connections>
+                                                <action selector="back:" destination="2dF-1v-giC" id="jJH-4v-Tv4"/>
+                                            </connections>
+                                        </barButtonItem>
+                                    </navigationItem>
+                                </items>
+                            </navigationBar>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Ccu-ap-YYO"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="OOB-Xs-tz3" firstAttribute="leading" secondItem="Ccu-ap-YYO" secondAttribute="leading" id="7kx-eC-YLj"/>
-                            <constraint firstItem="OOB-Xs-tz3" firstAttribute="top" secondItem="Ccu-ap-YYO" secondAttribute="top" id="Gj6-AJ-21m"/>
-                            <constraint firstItem="OOB-Xs-tz3" firstAttribute="centerY" secondItem="KcC-IT-yl3" secondAttribute="centerY" id="WII-lH-DYE"/>
-                            <constraint firstItem="OOB-Xs-tz3" firstAttribute="centerX" secondItem="KcC-IT-yl3" secondAttribute="centerX" id="Z9F-Kg-pve"/>
+                            <constraint firstItem="Eo7-Aq-G9x" firstAttribute="bottom" secondItem="Ccu-ap-YYO" secondAttribute="bottom" id="GKh-sf-xXr"/>
+                            <constraint firstItem="qE2-0Y-rq0" firstAttribute="leading" secondItem="Eo7-Aq-G9x" secondAttribute="leading" id="HYj-lS-P4x"/>
+                            <constraint firstItem="qE2-0Y-rq0" firstAttribute="trailing" secondItem="Eo7-Aq-G9x" secondAttribute="trailing" id="IBa-wA-VFU"/>
+                            <constraint firstItem="Eo7-Aq-G9x" firstAttribute="top" secondItem="qE2-0Y-rq0" secondAttribute="bottom" id="R3P-HP-mga"/>
+                            <constraint firstItem="Eo7-Aq-G9x" firstAttribute="leading" secondItem="Ccu-ap-YYO" secondAttribute="leading" id="aGj-Vd-2wR"/>
+                            <constraint firstItem="Eo7-Aq-G9x" firstAttribute="top" secondItem="Ccu-ap-YYO" secondAttribute="top" constant="44" id="hgN-RO-AWO"/>
+                            <constraint firstItem="qE2-0Y-rq0" firstAttribute="centerX" secondItem="KcC-IT-yl3" secondAttribute="centerX" id="rqj-lb-0SW"/>
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="pdfView" destination="OOB-Xs-tz3" id="g3S-0l-dPy"/>
+                        <outlet property="navigationBarItem" destination="lt4-aO-HLK" id="taq-8e-0VW"/>
+                        <outlet property="pdfView" destination="Eo7-Aq-G9x" id="dse-DJ-IK8"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="rqo-5A-lDw" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4107.2463768115949" y="171.42857142857142"/>
+            <point key="canvasLocation" x="4170" y="133"/>
         </scene>
     </scenes>
     <designables>

--- a/ios-app/Core/Constants.swift
+++ b/ios-app/Core/Constants.swift
@@ -114,6 +114,7 @@ struct Constants {
     static let VERIFY_PHONE_VIEW_CONTROLLER = "VerifyPhoneViewController"
     static let SHARE_TO_UNLOCK_VIEW_CONTROLLER = "ShareToUnlockViewController"
     static let LOGIN_ACTIVITY_VIEW_CONTROLLER = "LoginActivityViewController"
+    static let PDF_VIEW_CONTROLLER = "PDFViewController"
 
     
     static let PAGE = "page"

--- a/ios-app/UI/AttachmentDetailViewController.swift
+++ b/ios-app/UI/AttachmentDetailViewController.swift
@@ -207,11 +207,17 @@ class AttachmentDetailViewController: UIViewController, URLSessionDownloadDelega
 
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
         // This method will be called periodically to update the download progress
-        let progress = Float(totalBytesWritten) / Float(totalBytesExpectedToWrite)
-        let percentage = Int(progress * 100)
-        
-        DispatchQueue.main.async {
-            self.alertController.message = "\(Strings.LOADING) \(percentage)%\n\n"
+        if totalBytesExpectedToWrite > 0 {
+            let progress = Float(totalBytesWritten) / Float(totalBytesExpectedToWrite)
+            let percentage = Int(progress * 100)
+            
+            DispatchQueue.main.async {
+                self.alertController.message = "\(Strings.LOADING)\(percentage)%\n\n"
+            }
+        } else {
+            DispatchQueue.main.async {
+                self.alertController.message = "\(Strings.LOADING)\n\n" // or any other appropriate indication
+            }
         }
     }
     

--- a/ios-app/UI/AttachmentDetailViewController.swift
+++ b/ios-app/UI/AttachmentDetailViewController.swift
@@ -136,7 +136,7 @@ class AttachmentDetailViewController: UIViewController {
         var attachmentUrl = URL(string: content.attachment!.attachmentUrl)!
         if attachmentUrl.scheme == "http" {
             attachmentUrl = URL(string: "https://" + attachmentUrl.host! + attachmentUrl.path
-                                + "?" + attachmentUrl.query!)!
+                + "?" + attachmentUrl.query!)!
         }
         
         // Check if PDF exists in cache directory

--- a/ios-app/UI/AttachmentDetailViewController.swift
+++ b/ios-app/UI/AttachmentDetailViewController.swift
@@ -61,6 +61,7 @@ class AttachmentDetailViewController: UIViewController {
     let alertController = UIUtils.initProgressDialog(message: Strings.LOADING + "\n\n")
     var timer: Timer?
     var watermarkLabel: MarqueeLabel?
+    let cacheDirectoryURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -131,138 +132,84 @@ class AttachmentDetailViewController: UIViewController {
         downloadAttachmentButton.isHidden = false
     }
     
-//    @IBAction func viewAttachment(_ sender: UIButton) {
-//        var attachmentUrl = URL(string: content.attachment!.attachmentUrl)!
-//        if attachmentUrl.scheme == "http" {
-//            attachmentUrl = URL(string: "https://" + attachmentUrl.host! + attachmentUrl.path
-//                + "?" + attachmentUrl.query!)!
-//        }
-//        present(alertController, animated: false, completion: {
-//            self.loadPdf(url: attachmentUrl)
-//        })
-//    }
-//
-//    func loadPdf(url: URL) {
-//        let pdfDocument = PDFDocument(url: url)
-//        alertController.dismiss(animated: false, completion: {
-//            self.displayPdf(pdfDocument)
-//        })
-//    }
-//
-//    func displayPdf(_ pdfDocument: PDFDocument?) {
-//        if pdfDocument != nil {
-//            let backButton = UIBarButtonItem(title: "Back", style: .done, target: self,
-//                                             action:  #selector(back))
-//
-//            let pdfController = PDFViewController.createNew(with: pdfDocument!,
-//                                                            title: content.attachment!.title,
-//                                                            backButton: backButton)
-//            pdfController.navigationItem.rightBarButtonItem = nil
-//            watermarkLabel = initializeWatermark(view: pdfController.view)
-//            pdfController.view.addSubview(watermarkLabel!)
-//            startTimerToMoveWatermarkPosition()
-//            let navigationController = UINavigationController(rootViewController: pdfController)
-//            present(navigationController, animated: true)
-//            createContentAttempt()
-//        }
-//    }
+    @IBAction func viewAttachment(_ sender: UIButton) {
+        present(alertController, animated: false, completion: nil)
+        
+        var attachmentUrl = URL(string: content.attachment!.attachmentUrl)!
+        if attachmentUrl.scheme == "http" {
+            attachmentUrl = URL(string: "https://" + attachmentUrl.host! + attachmentUrl.path
+                                + "?" + attachmentUrl.query!)!
+        }
+        
+        // Check if PDF exists in cache directory
+        let pdfFilePath = cacheDirectoryURL.appendingPathComponent(attachmentUrl.lastPathComponent)
+        
+        if FileManager.default.fileExists(atPath: pdfFilePath.path) {
+            alertController.dismiss(animated: true) {
+                self.loadPdf(pdfFilePath)
+            }
+        } else {
+            downloadPDF(from: attachmentUrl, to: pdfFilePath) {
+                self.alertController.dismiss(animated: true) {
+                    self.loadPdf(pdfFilePath)
+                }
+            }
+        }
+    }
     
-    var pdfDocument: PDFDocument?
-        var pdfView: PDFView?
-        let cacheDirectoryURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
-
-        @IBAction func viewAttachment(_ sender: UIButton) {
-            // Show loading indicator
-            let loadingAlert = UIAlertController(title: nil, message: "Downloading PDF...", preferredStyle: .alert)
-            loadingAlert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: { _ in
-                // Cancel download if needed
-            }))
-            present(loadingAlert, animated: true, completion: nil)
-
-            var attachmentUrl = URL(string: content.attachment!.attachmentUrl)!
-            if attachmentUrl.scheme == "http" {
-                attachmentUrl = URL(string: "https://" + attachmentUrl.host! + attachmentUrl.path
-                    + "?" + attachmentUrl.query!)!
-            }
-
-            // Check if PDF exists in cache directory
-            let pdfFilePath = cacheDirectoryURL.appendingPathComponent(attachmentUrl.lastPathComponent)
-
-            if FileManager.default.fileExists(atPath: pdfFilePath.path) {
-                // Load PDF from cache
-                dismiss(animated: true) {
-                    self.loadPDFFromURL(pdfFilePath)
-                }
-            } else {
-                // Download PDF and save to cache
-                downloadPDF(from: attachmentUrl, to: pdfFilePath) {
-                    // Dismiss loading indicator after download completes
-                    loadingAlert.dismiss(animated: true) {
-                        self.loadPDFFromURL(pdfFilePath)
+    func downloadPDF(from url: URL, to destinationURL: URL, completion: @escaping () -> Void) {
+        URLSession.shared.downloadTask(with: url) { (location, response, error) in
+            guard let location = location, error == nil else {
+                print("Failed to download PDF: \(error?.localizedDescription ?? "Unknown error")")
+                DispatchQueue.main.async {
+                    // Dismiss loading indicator if download fails
+                    self.dismiss(animated: true) {
+                        // Display an error message to the user
+                        let alert = UIAlertController(title: "Error", message: "Failed to download PDF", preferredStyle: .alert)
+                        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+                        self.present(alert, animated: true, completion: nil)
                     }
                 }
+                return
             }
-        }
-
-        func downloadPDF(from url: URL, to destinationURL: URL, completion: @escaping () -> Void) {
-            URLSession.shared.downloadTask(with: url) { (location, response, error) in
-                guard let location = location, error == nil else {
-                    print("Failed to download PDF: \(error?.localizedDescription ?? "Unknown error")")
-                    DispatchQueue.main.async {
-                        // Dismiss loading indicator if download fails
-                        self.dismiss(animated: true) {
-                            // Display an error message to the user
-                            let alert = UIAlertController(title: "Error", message: "Failed to download PDF", preferredStyle: .alert)
-                            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-                            self.present(alert, animated: true, completion: nil)
-                        }
-                    }
-                    return
+            
+            do {
+                try FileManager.default.moveItem(at: location, to: destinationURL)
+                DispatchQueue.main.async {
+                    completion()
                 }
-
-                do {
-                    try FileManager.default.moveItem(at: location, to: destinationURL)
-                    DispatchQueue.main.async {
-                        completion()
-                    }
-                } catch {
-                    print("Failed to move downloaded file to cache directory: \(error)")
-                }
-            }.resume()
-        }
-
-
-        func loadPDFFromURL(_ url: URL) {
-            pdfDocument = PDFDocument(url: url)
-            if let pdfDocument = pdfDocument {
-                let storyboard =
-                    UIStoryboard(name: Constants.CHAPTER_CONTENT_STORYBOARD, bundle: nil)
-                let pdfViewController = storyboard.instantiateViewController(withIdentifier:
-                    Constants.PDF_VIEW_CONTROLLER) as! PDFViewController
-                pdfViewController.pdfDocument = pdfDocument
-                pdfViewController.contentTitle = content.attachment!.title
-                let navigationController = UINavigationController(rootViewController: pdfViewController)
-                navigationController.title = content.attachment!.title
-                present(navigationController, animated: true)
-            } else {
-                print("Failed to load PDF from URL: \(url)")
-                let alert = UIAlertController(title: "Error", message: "Failed to load PDF", preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-                self.present(alert, animated: true, completion: nil)
+            } catch {
+                print("Failed to move downloaded file to cache directory: \(error)")
             }
-
+        }.resume()
+    }
+    
+    
+    func loadPdf(_ url: URL) {
+        let pdfDocument = PDFDocument(url: url)
+        if let pdfDocument = pdfDocument {
+            let storyboard =
+            UIStoryboard(name: Constants.CHAPTER_CONTENT_STORYBOARD, bundle: nil)
+            let pdfViewController = storyboard.instantiateViewController(withIdentifier:
+                                                                            Constants.PDF_VIEW_CONTROLLER) as! PDFViewController
+            pdfViewController.pdfDocument = pdfDocument
+            pdfViewController.contentTitle = content.attachment!.title
+            let navigationController = UINavigationController(rootViewController: pdfViewController)
+            navigationController.title = content.attachment!.title
+            present(navigationController, animated: true)
+            createContentAttempt()
+        } else {
+            print("Failed to load PDF from URL: \(url)")
+            let alert = UIAlertController(title: "Error", message: "Failed to load PDF", preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+            self.present(alert, animated: true, completion: nil)
         }
-
-        @objc func back() {
-            dismissPDFView()
-            dismiss(animated: true, completion: nil)
-        }
-
-        func dismissPDFView() {
-            pdfView?.removeFromSuperview()
-            pdfView = nil
-            pdfDocument = nil
-        }
+        
+    }
+    
+    @objc func back() {
+        dismiss(animated: true, completion: nil)
+    }
     
     private func startTimerToMoveWatermarkPosition() {
         timer = Timer.scheduledTimer(timeInterval: 10.0, target: self, selector: #selector(moveWatermarkPosition), userInfo: nil, repeats: true)

--- a/ios-app/UI/AttachmentDetailViewController.swift
+++ b/ios-app/UI/AttachmentDetailViewController.swift
@@ -59,8 +59,6 @@ class AttachmentDetailViewController: UIViewController {
     var moveAnimationView: LottieAnimationView!
     var removeAnimationView: LottieAnimationView!
     let alertController = UIUtils.initProgressDialog(message: Strings.LOADING + "\n\n")
-    var timer: Timer?
-    var watermarkLabel: MarqueeLabel?
     let cacheDirectoryURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
     
     override func viewDidLoad() {
@@ -207,29 +205,6 @@ class AttachmentDetailViewController: UIViewController {
         
     }
     
-    @objc func back() {
-        dismiss(animated: true, completion: nil)
-    }
-    
-    private func startTimerToMoveWatermarkPosition() {
-        timer = Timer.scheduledTimer(timeInterval: 10.0, target: self, selector: #selector(moveWatermarkPosition), userInfo: nil, repeats: true)
-    }
-    
-    private func initializeWatermark(view: UIView) -> MarqueeLabel {
-        let watermarkLabel = MarqueeLabel.init(frame: CGRect(x: 0, y: 100, width: view.frame.width, height: 20), duration: 8.0, fadeLength: 0.0)
-        watermarkLabel.text = KeychainTokenItem.getAccount().padding(toLength: Int((view.frame.width)/2), withPad: " ", startingAt: 0)
-        watermarkLabel.numberOfLines = 1
-        return watermarkLabel
-    }
-    
-    @objc func moveWatermarkPosition() {
-        watermarkLabel?.frame.origin.y = CGFloat(Int.random(in: 0..<Int(self.view.frame.height)))
-    }
-
-    deinit {
-        self.timer?.invalidate()
-    }
-    
     @IBAction func downloadAttachment(_ sender: UIButton) {
         var attachmentUrl = URL(string: content.attachment!.attachmentUrl)!
         UIApplication.shared.openURL(attachmentUrl)
@@ -300,9 +275,9 @@ class AttachmentDetailViewController: UIViewController {
         contentView.layoutIfNeeded()
     }
     
-//    @objc func back() {
-//        dismiss(animated: true, completion: nil)
-//    }
+    @objc func back() {
+        dismiss(animated: true, completion: nil)
+    }
     
 }
 

--- a/ios-app/UI/Dashboard/PDFViewController.swift
+++ b/ios-app/UI/Dashboard/PDFViewController.swift
@@ -31,8 +31,6 @@ class PDFViewController: UIViewController {
         pdfView.documentView?.isUserInteractionEnabled = false
         
         navigationBarItem.title = contentTitle
-//        navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Back", style: .plain, target: self, action: #selector(back))
-//        navigationItem.title = contentTitle
     }
     
     func addPanGesture() {

--- a/ios-app/UI/Dashboard/PDFViewController.swift
+++ b/ios-app/UI/Dashboard/PDFViewController.swift
@@ -1,0 +1,87 @@
+import UIKit
+import PDFKit
+import MarqueeLabel
+
+
+class PDFViewController: UIViewController {
+    var pdfDocument: PDFDocument?
+    @IBOutlet var pdfView: PDFView!
+    private var currentPageIndex = 0
+    var watermarkLabel: MarqueeLabel?
+    var timer: Timer?
+    var contentTitle: String!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupPDFView()
+        addPanGesture()
+        watermarkLabel = initializeWatermark(view: view)
+        view.addSubview(watermarkLabel!)
+        startTimerToMoveWatermarkPosition()
+    }
+
+    private func initializeWatermark(view: UIView) -> MarqueeLabel {
+        let watermarkLabel = MarqueeLabel.init(frame: CGRect(x: 0, y: 100, width: view.frame.width, height: 20), duration: 8.0, fadeLength: 0.0)
+        watermarkLabel.text = KeychainTokenItem.getAccount().padding(toLength: Int((view.frame.width)/2), withPad: " ", startingAt: 0)
+        watermarkLabel.numberOfLines = 1
+        return watermarkLabel
+    }
+
+    private func startTimerToMoveWatermarkPosition() {
+        timer = Timer.scheduledTimer(timeInterval: 10.0, target: self, selector: #selector(moveWatermarkPosition), userInfo: nil, repeats: true)
+    }
+
+    @objc func moveWatermarkPosition() {
+        watermarkLabel?.frame.origin.y = CGFloat(Int.random(in: 0..<Int(self.view.frame.height)))
+    }
+
+    func setupPDFView() {
+        pdfView.autoresizingMask = [.flexibleWidth,.flexibleHeight]
+        pdfView.displayMode = .singlePage
+        pdfView.displayDirection = .horizontal
+        pdfView.minScaleFactor = 0.5
+        pdfView.maxScaleFactor = 5.0
+        pdfView.autoScales = true
+        pdfView.document = pdfDocument
+                   
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Back", style: .plain, target: self, action: #selector(back))
+        navigationItem.title = contentTitle
+    }
+
+    @objc func back(_ sender: Any) {
+        dismiss(animated: true)
+    }
+
+    func addPanGesture() {
+        let panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePanGesture))
+        pdfView.addGestureRecognizer(panGesture)
+    }
+
+    @objc func handlePanGesture(_ recognizer: UIPanGestureRecognizer) {
+        guard let pdfDocument = pdfDocument else {
+            return
+        }
+        
+        guard recognizer.state == .ended else { return }
+
+        let translation = recognizer.translation(in: pdfView)
+        let velocity = recognizer.velocity(in: pdfView)
+
+        if translation.x < -50 && velocity.x < -500 && currentPageIndex < pdfDocument.pageCount {
+            print(pdfView.scaleFactor)
+            // Swipe left
+            currentPageIndex += 1
+            if let nextPage = pdfDocument.page(at: currentPageIndex) {
+                pdfView.go(to: nextPage)
+            }
+        } else if translation.x > 50 && velocity.x > 500 && currentPageIndex > 0 {
+            // Swipe right
+            currentPageIndex -= 1
+            if let prevPage = pdfDocument.page(at: currentPageIndex) {
+                pdfView.go(to: prevPage)
+            }
+        }
+    }
+
+}
+

--- a/ios-app/UI/Dashboard/PDFViewController.swift
+++ b/ios-app/UI/Dashboard/PDFViewController.swift
@@ -10,7 +10,7 @@ class PDFViewController: UIViewController {
     var watermarkLabel: MarqueeLabel?
     var timer: Timer?
     var contentTitle: String!
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setupPDFView()
@@ -19,22 +19,22 @@ class PDFViewController: UIViewController {
         view.addSubview(watermarkLabel!)
         startTimerToMoveWatermarkPosition()
     }
-
+    
     private func initializeWatermark(view: UIView) -> MarqueeLabel {
         let watermarkLabel = MarqueeLabel.init(frame: CGRect(x: 0, y: 100, width: view.frame.width, height: 20), duration: 8.0, fadeLength: 0.0)
         watermarkLabel.text = KeychainTokenItem.getAccount().padding(toLength: Int((view.frame.width)/2), withPad: " ", startingAt: 0)
         watermarkLabel.numberOfLines = 1
         return watermarkLabel
     }
-
+    
     private func startTimerToMoveWatermarkPosition() {
         timer = Timer.scheduledTimer(timeInterval: 10.0, target: self, selector: #selector(moveWatermarkPosition), userInfo: nil, repeats: true)
     }
-
+    
     @objc func moveWatermarkPosition() {
         watermarkLabel?.frame.origin.y = CGFloat(Int.random(in: 0..<Int(self.view.frame.height)))
     }
-
+    
     func setupPDFView() {
         pdfView.autoresizingMask = [.flexibleWidth,.flexibleHeight]
         pdfView.displayMode = .singlePage
@@ -43,32 +43,32 @@ class PDFViewController: UIViewController {
         pdfView.maxScaleFactor = 5.0
         pdfView.autoScales = true
         pdfView.document = pdfDocument
-                   
+        pdfView.documentView?.isUserInteractionEnabled = false
+        
         navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Back", style: .plain, target: self, action: #selector(back))
         navigationItem.title = contentTitle
     }
-
+    
     @objc func back(_ sender: Any) {
-        dismiss(animated: true)
+        self.dismiss(animated: true)
     }
-
+    
     func addPanGesture() {
         let panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePanGesture))
         pdfView.addGestureRecognizer(panGesture)
     }
-
+    
     @objc func handlePanGesture(_ recognizer: UIPanGestureRecognizer) {
         guard let pdfDocument = pdfDocument else {
             return
         }
         
         guard recognizer.state == .ended else { return }
-
+        
         let translation = recognizer.translation(in: pdfView)
         let velocity = recognizer.velocity(in: pdfView)
-
+        
         if translation.x < -50 && velocity.x < -500 && currentPageIndex < pdfDocument.pageCount {
-            print(pdfView.scaleFactor)
             // Swipe left
             currentPageIndex += 1
             if let nextPage = pdfDocument.page(at: currentPageIndex) {
@@ -81,7 +81,7 @@ class PDFViewController: UIViewController {
                 pdfView.go(to: prevPage)
             }
         }
+        pdfView.autoScales = true
     }
-
+    
 }
-

--- a/ios-app/UI/Dashboard/PDFViewController.swift
+++ b/ios-app/UI/Dashboard/PDFViewController.swift
@@ -84,4 +84,8 @@ class PDFViewController: UIViewController {
         pdfView.autoScales = true
     }
     
+    deinit {
+        self.timer?.invalidate()
+    }
+    
 }


### PR DESCRIPTION
- In this commit, we replaced the `PDFReader` framework with `PDFKit`.
- Previously, when loading a PDF from a URL, the app would store it in RAM. If the PDF exceeded 300 MB, the app would run out of memory and crash.
- In this commit, we revised the approach to download and cache the PDF locally before passing it to the PDF viewer. This adjustment reduces RAM consumption.