### PR TITLE
fix: Support to view sections instructions during attempt

### DIFF
--- a/ios-app/AppDelegate.swift
+++ b/ios-app/AppDelegate.swift
@@ -116,7 +116,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             SentrySDK.setUser(user)
         }
         
-        let config = Realm.Configuration(schemaVersion: 35)
+        let config = Realm.Configuration(schemaVersion: 36)
         Realm.Configuration.defaultConfiguration = config
         let viewController:UIViewController
         

--- a/ios-app/Base.lproj/TestEngine.storyboard
+++ b/ios-app/Base.lproj/TestEngine.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="yph-KO-fST">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="yph-KO-fST">
     <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -487,11 +487,21 @@
                                             <constraint firstAttribute="height" constant="1" id="iZI-ZE-9EQ"/>
                                         </constraints>
                                     </view>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rgg-GG-pK5">
+                                        <rect key="frame" x="206" y="4.5" width="114" height="34.5"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="Instructions"/>
+                                        <connections>
+                                            <action selector="showCurrentSectionInstructions:" destination="Lki-87-nF0" eventType="touchUpInside" id="6PO-YK-TIl"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="45" id="NB0-Yx-nQH"/>
+                                    <constraint firstAttribute="bottom" secondItem="rgg-GG-pK5" secondAttribute="bottom" constant="6" id="QJO-Hx-sAj"/>
                                     <constraint firstAttribute="bottom" secondItem="kM0-wy-QnV" secondAttribute="bottom" id="RAp-af-2DR"/>
+                                    <constraint firstAttribute="trailing" secondItem="rgg-GG-pK5" secondAttribute="trailing" id="Tq4-oG-VBI"/>
                                     <constraint firstItem="kM0-wy-QnV" firstAttribute="leading" secondItem="5ci-5U-2s9" secondAttribute="leading" id="Tuu-wT-xWU"/>
                                     <constraint firstAttribute="trailing" secondItem="kM0-wy-QnV" secondAttribute="trailing" id="xUm-Be-lLW"/>
                                 </constraints>
@@ -599,6 +609,7 @@
                         <outlet property="prevButton" destination="zo1-XM-udl" id="rJY-Dk-SFe"/>
                         <outlet property="previousButtonLayout" destination="9ln-sw-qFS" id="yuo-mE-cYV"/>
                         <outlet property="questionsContainerView" destination="BMp-mq-B4q" id="Yt9-yp-wnK"/>
+                        <outlet property="sectionInstructionsButton" destination="rgg-GG-pK5" id="7Mj-Wm-uvZ"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Bbo-Tv-YPf" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -1357,7 +1368,7 @@
         <image name="ic_navigate_next" width="24" height="24"/>
         <image name="ic_pause_circle_outline_white" width="24" height="24"/>
         <image name="ic_thumb_up_18pt" width="18" height="18"/>
-        <image name="language_icon" width="128" height="128"/>
+        <image name="language_icon" width="20" height="20"/>
         <image name="language_icon_white" width="288" height="288"/>
         <image name="testpress_calendar_icon" width="24" height="24"/>
         <image name="testpress_duration" width="25" height="25"/>
@@ -1368,7 +1379,7 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="tintColor">
-            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/ios-app/Model/AttemptSection.swift
+++ b/ios-app/Model/AttemptSection.swift
@@ -34,6 +34,7 @@ class AttemptSection: DBModel {
     @objc dynamic var remainingTime: String = ""
     @objc dynamic var attemptId: Int = -1
     @objc dynamic var name: String = ""
+    @objc dynamic var instructions: String = ""
     @objc dynamic var duration: String = ""
     @objc dynamic var order: Int = 0
     
@@ -50,6 +51,7 @@ class AttemptSection: DBModel {
         remainingTime <- map["remaining_time"]
         attemptId <- map["attempt_id"]
         name <- map["name"]
+        instructions <- map["instructions"]
         duration <- map["duration"]
         order <- map["order"]
     }

--- a/ios-app/UI/TestEngineViewController.swift
+++ b/ios-app/UI/TestEngineViewController.swift
@@ -491,14 +491,16 @@ class TestEngineViewController: BaseQuestionsPageViewController {
     
     @IBAction func showCurrentSectionInstructions(_ sender: Any) {
         if !isCurrentSectionHasInstructions() { return }
-        var instructions = self.sections[self.currentSection].instructions
+        let instructions = self.sections[self.currentSection].instructions
 
         instructionsPopup = UIAlertController(title: "Instructions", message: nil, preferredStyle: .alert)
-        webView.backgroundColor = UIColor.clear
-        webView.sizeToFit()
-        webView.loadHTMLString(instructions, baseURL: Bundle.main.bundleURL)
-        instructionsPopup!.view.addSubview(webView)
         instructionsPopup!.addAction(UIAlertAction(title: "Close", style: .cancel, handler: nil))
+        
+        if let attributedString = try? NSAttributedString(data: instructions.data(using: .utf8)!,
+                                                           options: [.documentType: NSAttributedString.DocumentType.html],
+                                                           documentAttributes: nil) {
+            instructionsPopup!.setValue(attributedString, forKey: "attributedMessage")
+        }
         present(instructionsPopup!, animated: true, completion: nil)
     }
     

--- a/ios-app/UI/TestEngineViewController.swift
+++ b/ios-app/UI/TestEngineViewController.swift
@@ -26,7 +26,6 @@
 import DropDown
 import UIKit
 import RealmSwift
-import WebKit
 
 class TestEngineViewController: BaseQuestionsPageViewController {
     
@@ -47,7 +46,6 @@ class TestEngineViewController: BaseQuestionsPageViewController {
     var selectedPlainSpinnerItemOffset: Int = 0
     var navigationButtonPressed: Bool = false
     @IBOutlet weak var sectionInstructionsButton: UIButton!
-    var webView: WKWebView!
     var instructionsPopup: UIAlertController?
     /**
      * Map of subjects/sections & its starting point(first question index)
@@ -64,7 +62,6 @@ class TestEngineViewController: BaseQuestionsPageViewController {
         setupPauseButtonGesture()
         initializeDropDownContainerForSections()
         setupSectionInstructionsBtn()
-        webView = WKWebView()
         
         if !firstAttemptOfLockedSectionExam {
             nextButton.setTitleColor(Colors.getRGB(Colors.MATERIAL_RED), for: .disabled)


### PR DESCRIPTION
- Introduced a new support that allows users to view section instructions during an attempt. 
- This feature is implemented by adding a button to the exam page. When users click on this button, instructions are displayed in a popup.