### PR TITLE
fix: Sections dropdown not shown in exam page

### DIFF
--- a/ios-app/Model/Exam.swift
+++ b/ios-app/Model/Exam.swift
@@ -152,4 +152,8 @@ class Exam: DBModel {
     func hasMultipleLanguages() -> Bool {
         return languages.count > 1
     }
+    
+    func IsExamUsingIBPSTemplate() -> Bool{
+        return templateType == 2
+    }
 }

--- a/ios-app/UI/TestEngineViewController.swift
+++ b/ios-app/UI/TestEngineViewController.swift
@@ -728,8 +728,10 @@ class TestEngineViewController: BaseQuestionsPageViewController {
 extension TestEngineViewController: QuestionsPageViewDelegate {
     
     func questionsDidLoad() {
+        let shouldGroupAttemptItemsBasedOnSubject = exam?.IsExamUsingIBPSTemplate() == true && sections.count <= 1
+        
         var result: (spinnerItemsList: [String], groupedAttemptItems: OrderedDictionary<String, [AttemptItem]>)
-        if sections.count <= 1 && exam != nil && (exam!.templateType == 2 || unlockedSectionExam) {
+        if (shouldGroupAttemptItemsBasedOnSubject || unlockedSectionExam) {
             result = unlockedSectionExam ? groupAttemptItemsBasedOnSection() : groupAttemptItemsBasedOnSubject()
             setUpSectionsDropDown(spinnerItemsList: result.spinnerItemsList, groupedAttemptItems: result.groupedAttemptItems)
         }


### PR DESCRIPTION
- Sections dropdown was not displayed on the Exam page if any section did not have a duration.
- On Android and the Web, if any section lacks a duration, we switch to an unlocked section exam mode. This mode allows students to switch between sections without needing to end the current section. 
- Although we have this logic in our iOS app, an incorrect if condition was added, preventing the sections dropdown from appearing on the exam page.
- So corrected the if condition to ensure the Sections dropdown appears correctly.