### PR TITLE
fix: Add Privacy Usage Description for `Contacts` and `Calendars`.

### DIFF
--- a/ios-app/Info.plist
+++ b/ios-app/Info.plist
@@ -53,8 +53,12 @@
 	</dict>
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>We will use your Bluetooth to access your Bluetooth headphones.</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>This app requires access to your calendar to schedule and manage meetings.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>To take image &amp; upload in comments/forum</string>
+	<key>NSContactsUsageDescription</key>
+	<string>This app requires access to your contacts to allow you to invite others to meetings.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>For people to hear you during meetings, we need access to your microphone.</string>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/ios-app/Info.plist
+++ b/ios-app/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIUserInterfaceStyle</key>
-	<string>Light</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
@@ -53,7 +51,7 @@
 	</dict>
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>We will use your Bluetooth to access your Bluetooth headphones.</string>
-	<key>NSCalendarsFullAccessUsageDescription</key>
+	<key>NSCalendarsUsageDescription</key>
 	<string>This app requires access to your calendar to schedule and manage meetings.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>To take image &amp; upload in comments/forum</string>
@@ -92,6 +90,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>


### PR DESCRIPTION
- In this commit, we are adding Privacy Usage Descriptions for `Contacts` and `Calendars`.
- The Zoom SDK uses these privacy options, and although our app doesn't utilize these features, The App Store Connect policy requires us to provide purpose strings explaining the use of these privacy options.