### PR TITLE
fix: App crash while seeking the live using seek bar

### DIFF
--- a/ios-app/UI/LiveStreamContentViewController.swift
+++ b/ios-app/UI/LiveStreamContentViewController.swift
@@ -46,6 +46,7 @@ class LiveStreamContentViewController: UIViewController {
         addChild(playerViewController!)
         playerContainer.addSubview(playerViewController!.view)
         playerViewController!.view.frame = playerContainer.bounds
+        playerViewController.playerView.isLive = true
     }
     
     func setupLiveChatView(){

--- a/ios-app/Views/VideoPlayerView.swift
+++ b/ios-app/Views/VideoPlayerView.swift
@@ -28,6 +28,28 @@ class VideoPlayerView: UIView {
     var watermarkLabel: MarqueeLabel?
     var contentKeySessionDelegate: DRMKeySessionDelegate!
     var videoPlayerResourceLoaderDelegate: VideoPlayerResourceLoaderDelegate!
+   
+    var isLive: Bool {
+        guard let currentItem = player?.currentItem else {
+            return false
+        }
+        return currentItem.duration.isIndefinite
+    }
+    
+    public var videoDuration: CMTime {
+        guard let currentItem = player?.currentItem else {
+            return .invalid
+        }
+
+        if isLive {
+            guard let seekableTimeRange = currentItem.seekableTimeRanges.last?.timeRangeValue else {
+                return .invalid
+            }
+            return CMTime(seconds: seekableTimeRange.end.seconds, preferredTimescale: 1_000)
+        } else {
+            return currentItem.duration
+        }
+    }
     
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
@@ -146,7 +168,7 @@ class VideoPlayerView: UIView {
             let seconds = CMTimeGetSeconds(progressTime)
             if (self.player?.currentItem != nil) {
                 let loadedDuration = CMTimeGetSeconds((self.player?.availableDuration())!)
-                self.controlsContainerView.updateDuration(seconds:seconds, videoDuration: CMTimeGetSeconds((self.player?.currentItem?.duration)!))
+                self.controlsContainerView.updateDuration(seconds:seconds, videoDuration: self.videoDuration.seconds)
                 self.controlsContainerView.updateLoadedDuration(seconds:loadedDuration)
             }
         })

--- a/ios-app/Views/VideoPlayerView.swift
+++ b/ios-app/Views/VideoPlayerView.swift
@@ -29,13 +29,7 @@ class VideoPlayerView: UIView {
     var contentKeySessionDelegate: DRMKeySessionDelegate!
     var videoPlayerResourceLoaderDelegate: VideoPlayerResourceLoaderDelegate!
    
-    var isLive: Bool {
-        guard let currentItem = player?.currentItem else {
-            return false
-        }
-        return currentItem.duration.isIndefinite
-    }
-    
+    var isLive: Bool = false
     public var videoDuration: CMTime {
         guard let currentItem = player?.currentItem else {
             return .invalid


### PR DESCRIPTION
- The app was crashing when seeking in a live stream because AVPlayerItem returns an indefinite duration for live streams, causing incorrect seek calculations. 
- This commit fixes the issue by using a different method to obtain the live stream duration.