### PR TITLE
fix: Log API failures during exam attempt in Sentry

### DIFF
--- a/ios-app/Model/TPError.swift
+++ b/ios-app/Model/TPError.swift
@@ -25,6 +25,7 @@
 
 import UIKit
 import Alamofire
+import Sentry
 
 public class TPError: Error {
     
@@ -121,6 +122,18 @@ public class TPError: Error {
         return TPModelMapper<T>().mapFromJSON(json: message!)
     }
     
+    public func logErrorToSentry() {
+        let event = Event(level: .error)
+        event.message = SentryMessage(formatted: self.message ?? "Some error occured")
+        event.extra = [
+            "statusCode": self.statusCode,
+            "error_detail": self.error_detail ?? "",
+            "error_code": self.error_code ?? "",
+            "kind": "\(self.kind)"
+        ]
+        
+        SentrySDK.capture(event: event)
+    }
 }
 
 

--- a/ios-app/UI/TestEngineViewController.swift
+++ b/ios-app/UI/TestEngineViewController.swift
@@ -357,6 +357,7 @@ class TestEngineViewController: BaseQuestionsPageViewController {
             completion: {
                 attempt, error in
                 if let error = error {
+                    error.logErrorToSentry()
                     self.loadingDialogController.message = Strings.PLEASE_WAIT + "\n\n"
                     self.showAlert(error: error, retryHandler: { self.sendHeartBeat() })
                     return
@@ -390,6 +391,7 @@ class TestEngineViewController: BaseQuestionsPageViewController {
                             self.showMaxQuestionsAttemptedError(error: error)
                             self.setCurrentQuestion(index: index)
                         } else {
+                            error.logErrorToSentry()
                             self.showAlert(error: error, retryHandler: {
                                 self.saveAnswer(index: index, completionHandler: completionHandler)
                             })
@@ -457,6 +459,7 @@ class TestEngineViewController: BaseQuestionsPageViewController {
             completion: {
                 attemptSection, error in
                 if let error = error {
+                    error.logErrorToSentry()
                     self.showAlert(
                         error: error,
                         message: Strings.EXAM_PAUSED_CHECK_INTERNET_TO_END,
@@ -510,6 +513,7 @@ class TestEngineViewController: BaseQuestionsPageViewController {
             completion: {
                 attemptSection, error in
                 if let error = error {
+                    error.logErrorToSentry()
                     self.showAlert(error: error, retryHandler: { self.startSection() })
                     return
                 }
@@ -554,6 +558,7 @@ class TestEngineViewController: BaseQuestionsPageViewController {
             completion: {
                 attempt, error in
                 if let error = error {
+                    error.logErrorToSentry()
                     self.showAlert(
                         error: error,
                         message: Strings.EXAM_PAUSED_CHECK_INTERNET_TO_END,


### PR DESCRIPTION
- Added a method to the TPError class for logging errors to Sentry
- Called this method on API failures occurring during exam attempts.