### PR TITLE
fix: Open IELTS and CTET Exam in WebView

### DIFF
--- a/ios-app/AppDelegate.swift
+++ b/ios-app/AppDelegate.swift
@@ -110,7 +110,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             userDefaults.synchronize() // Forces the app to update UserDefaults
         }
         
-        let config = Realm.Configuration(schemaVersion: 38)
+        let config = Realm.Configuration(schemaVersion: 39)
         Realm.Configuration.defaultConfiguration = config
         let viewController:UIViewController
         

--- a/ios-app/Model/Exam.swift
+++ b/ios-app/Model/Exam.swift
@@ -65,6 +65,7 @@ class Exam: DBModel {
     @objc dynamic var enableQuizMode: Bool = false;
     @objc dynamic var selectedLanguage: Language?
     var languages = List<Language>()
+    @objc dynamic var examStartUrl: String?
     
     override public static func primaryKey() -> String? {
         return "id"
@@ -111,6 +112,7 @@ class Exam: DBModel {
         enableQuizMode <- map["enable_quiz_mode"]
         selectedLanguage <- map["selected_language"]
         languages <- (map["languages"], ListTransform<Language>())
+        examStartUrl <- map["exam_start_url"]
     }
     
     func hasStarted() -> Bool {
@@ -156,4 +158,9 @@ class Exam: DBModel {
     func IsExamUsingIBPSTemplate() -> Bool{
         return templateType == 2
     }
+}
+
+struct ExamTemplateType {
+    static let IELTS_TEMPLATE = 12
+    static let CTET_TEMPLATE = 15
 }

--- a/ios-app/UI/StartExamScreenViewController.swift
+++ b/ios-app/UI/StartExamScreenViewController.swift
@@ -221,6 +221,11 @@ class StartExamScreenViewController: UIViewController {
     }
     
     @IBAction func startExam(_ sender: UIButton) {
+        if [ExamTemplateType.IELTS_TEMPLATE, ExamTemplateType.CTET_TEMPLATE].contains(exam.templateType) {
+            startExamInWebview()
+            return
+        }
+
         if (exam.hasMultipleLanguages() && exam.selectedLanguage == nil){
             showLanguages()
             return
@@ -236,6 +241,21 @@ class StartExamScreenViewController: UIViewController {
             startExam(StartExamScreenViewController.REGULAR_ATTEMPT)
         }
     }
+    
+    private func startExamInWebview() {
+        guard let exam = exam, let examStartUrl = exam.examStartUrl else {
+            return
+        }
+        let webViewController = WebViewController()
+        webViewController.url = "&next=\(examStartUrl)"
+        webViewController.title = exam.title
+        webViewController.useSSOLogin = true
+        webViewController.shouldOpenLinksWithinWebview = true
+        webViewController.displayNavbar = true
+        webViewController.modalPresentationStyle = .fullScreen
+        present(webViewController, animated: true, completion: nil)
+    }
+
     
     private func showExamModePopUp(_ sender: UIButton) {
         let actionSheet = UIAlertController(title: "Select Exam Mode", message: nil, preferredStyle: .actionSheet)


### PR DESCRIPTION
- Previously, IELTS and CTET Exam templates were not supported on the IOS App.
- In this commit, we added support to open IELTS  and CTET Exams in a WebView.