### PR TITLE
fix: Prevent screen recording the app

### DIFF
--- a/ios-app/Model/InstituteSettings.swift
+++ b/ios-app/Model/InstituteSettings.swift
@@ -65,6 +65,7 @@ class InstituteSettings: DBModel {
     @objc dynamic var sentryDSN: String = ""
     @objc dynamic var disableForgotPassword: Bool = false
     @objc dynamic var enableCustomTest: Bool = false
+    @objc dynamic var AllowScreenShotInApp: Bool = false
 
     public override func mapping(map: ObjectMapper.Map) {
         verificationMethod <- map["verification_method"]
@@ -102,6 +103,7 @@ class InstituteSettings: DBModel {
         sentryDSN <- map["ios_sentry_dns"]
         disableForgotPassword <- map["disable_forgot_password"]
         enableCustomTest <- map["enable_custom_test"]
+        AllowScreenShotInApp <- map["allow_screenshot_in_app"]
     }
     
     override public static func primaryKey() -> String? {


### PR DESCRIPTION
- Implemented screen recording restriction for users when the institute disables screenshots in the app. 
- This commit only restricts screen recording, as it is not possible to prevent users from taking screenshots in an iOS app due to the lack of detection mechanisms.
