### PR TITLE
fix: API failure on automatic section closure at end of duration

### DIFF
--- a/ios-app/Extensions/String.swift
+++ b/ios-app/Extensions/String.swift
@@ -16,11 +16,15 @@ extension String {
     }
     
     var secondsFromString : Int{
-        var n = 3600
-        return self.components(separatedBy: ":").reduce(0) {
-            defer { n /= 60 }
-            return $0 + (Int($1) ?? 0) * n
-        }
+        let components = self.components(separatedBy: ":")
+            guard components.count == 3 else { return 0 } // Handle invalid format
+
+            let hours = Double(components[0]) ?? 0
+            let minutes = Double(components[1]) ?? 0
+            let secondsComponents = components[2].components(separatedBy: ".")
+            let seconds = Double(secondsComponents[0]) ?? 0
+            let totalSeconds = (hours * 3600) + (minutes * 60) + seconds
+            return Int(totalSeconds)
     }
 }
 


### PR DESCRIPTION
- For section-based exams, a network error occurs when the first section ends due to incorrect time parsing.
- The remaining time is received in the format `0:00:00.000000` (including milliseconds).
- Our current parsing logic only handles the `0:00:00` format, resulting in the loss of seconds from the time string.
- This leads to an incorrect timer display and premature exam-ending attempt.
- Since these exams have section timers and prevent early section ending, the API call to end the section fails.
- By addressing the time parsing issue, we can prevent the network error and ensure correct exam behavior.