### PR TITLE
fix: Preemptive Section Ending not working in Exam

### DIFF
--- a/ios-app/Core/Strings.swift
+++ b/ios-app/Core/Strings.swift
@@ -167,7 +167,7 @@ struct Strings {
     static let EXAM_PAUSED_CHECK_INTERNET_TO_END = "Exam is paused, Please check your internet connection & try again."
     
     static let CANNOT_SWITCH_SECTION = "Can\'t Switch Section!"
-    static let CANNOT_SWITCH_IN_FIRST_ATTEMPT = "You can\'t switch sections in the first attempt."
+    static let CANNOT_SWITCH_IN_FIRST_ATTEMPT = "Section is locked. Switching section is not allowed."
     static let ALREADY_SUBMITTED = "You have already submitted this section."
     static let SWITCH_SECTION = "Switch Section?"
     static let SWITCH_SECTION_MESSAGE = "Are you sure want to move to the next section? You won\'t be able to switch back to this section."

--- a/ios-app/UI/TestEngineViewController.swift
+++ b/ios-app/UI/TestEngineViewController.swift
@@ -195,15 +195,7 @@ class TestEngineViewController: BaseQuestionsPageViewController {
             }
             self.onSwitchLockedSection(index: index)
         }
-        firstAttemptOfLockedSectionExam = isFirstCourseContentAttempt() || isFirstExamAttempt()
-    }
-
-    private func isFirstCourseContentAttempt() -> (Bool) {
-        return (courseContent != nil && courseContent.attemptsCount <= 1)
-    }
-    
-    private func isFirstExamAttempt() -> (Bool) {
-        return (courseContent == nil && (exam!.attemptsCount == 0 || (exam!.attemptsCount == 1 && exam!.pausedAttemptsCount == 1)))
+        firstAttemptOfLockedSectionExam = !(exam?.allowPreemptiveSectionEnding ?? false)
     }
     
     private func setUpDropDownForSections() {


### PR DESCRIPTION
- Previously, the preemptive section ending feature was not functioning correctly in the exam.
- Section switching is now handled based on the allowPreemptiveSectionEnding field.
- Updated the section locked message.