### PR TITLE
fix: Use institute's domain URL for encryption key requests

### DIFF
--- a/ios-app/Repository/EncryptionKeyRepository.swift
+++ b/ios-app/Repository/EncryptionKeyRepository.swift
@@ -14,7 +14,7 @@ class EncryptionKeyRepository {
         let encryptionKeyUrl = URLUtils.convertURLSchemeToHttps(url: url)
         let baseURLComponents = URLComponents(string: Constants.BASE_URL)!
         let baseHost = baseURLComponents.host!
-        // Change the domain to the testpress domain
+        // Update the custom domain to the Testpress domain
         let finalURL = URLUtils.changeDomain(url: encryptionKeyUrl, newDomain: baseHost)
         fetchFromNetwork(url: finalURL) { key in
             onSuccess(key)

--- a/ios-app/Repository/EncryptionKeyRepository.swift
+++ b/ios-app/Repository/EncryptionKeyRepository.swift
@@ -12,7 +12,11 @@ import Foundation
 class EncryptionKeyRepository {
     func load(url: URL, onSuccess: @escaping(Data) -> Void) {
         let encryptionKeyUrl = URLUtils.convertURLSchemeToHttps(url: url)
-        fetchFromNetwork(url: encryptionKeyUrl) { key in
+        let baseURLComponents = URLComponents(string: Constants.BASE_URL)!
+        let baseHost = baseURLComponents.host!
+        // Change the domain to the testpress domain
+        let finalURL = URLUtils.changeDomain(url: encryptionKeyUrl, newDomain: baseHost)
+        fetchFromNetwork(url: finalURL) { key in
             onSuccess(key)
         }
     }

--- a/ios-app/Utils/URLUtils.swift
+++ b/ios-app/Utils/URLUtils.swift
@@ -21,4 +21,13 @@ class URLUtils {
         urlComponents!.scheme = scheme
         return urlComponents!.url!
     }
+    
+    static func changeDomain(url: URL, newDomain: String) -> URL {
+        var urlComponents = URLComponents(
+            url: url,
+            resolvingAgainstBaseURL: false
+        )
+        urlComponents!.host = URLComponents(string: newDomain)!.host
+        return urlComponents!.url!
+    }
 }


### PR DESCRIPTION
- Previously, we used subdomain URLs (from the video manifest file) for encryption key requests. While this approach worked, it posed a problem if the institute changed its subdomain. In such cases, all video manifests needed to be updated on the backend, leading to videos not playing until the updates were made.
- This commit addresses the issue by using the institute's domain URL for encryption key requests, rather than the host specified in the video manifest file. This change avoids the need to update video manifests and ensures continuous video playback even if the institute's subdomain changes.