### PR TITLE
refactor: Replace Realm Object Usage with DBModel

### DIFF
--- a/ios-app.xcodeproj/project.pbxproj
+++ b/ios-app.xcodeproj/project.pbxproj
@@ -104,7 +104,7 @@
 		257BB697246AC22B00524D2C /* ExamQuestionsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257BB696246AC22B00524D2C /* ExamQuestionsResponse.swift */; };
 		257BB699246AC2ED00524D2C /* ExamQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257BB698246AC2ED00524D2C /* ExamQuestion.swift */; };
 		258036A52743AA2400397639 /* DRMKeySessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 258036A42743AA2400397639 /* DRMKeySessionDelegate.swift */; };
-		2586782728ABB81700E149B5 /* Object.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2586782628ABB81700E149B5 /* Object.swift */; };
+		2586782728ABB81700E149B5 /* DBModel+Detachable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2586782628ABB81700E149B5 /* DBModel+Detachable.swift */; };
 		2590B1FA2510BB90003C0A03 /* VideoConference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2590B1F92510BB90003C0A03 /* VideoConference.swift */; };
 		2590B1FC2510C9F2003C0A03 /* VideoConferenceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2590B1FB2510C9F2003C0A03 /* VideoConferenceViewController.swift */; };
 		2592868A2473B1E00035EBA4 /* QuizReviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259286892473B1E00035EBA4 /* QuizReviewViewController.swift */; };
@@ -565,7 +565,7 @@
 		257BB696246AC22B00524D2C /* ExamQuestionsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExamQuestionsResponse.swift; sourceTree = "<group>"; };
 		257BB698246AC2ED00524D2C /* ExamQuestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExamQuestion.swift; sourceTree = "<group>"; };
 		258036A42743AA2400397639 /* DRMKeySessionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRMKeySessionDelegate.swift; sourceTree = "<group>"; };
-		2586782628ABB81700E149B5 /* Object.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Object.swift; sourceTree = "<group>"; };
+		2586782628ABB81700E149B5 /* DBModel+Detachable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBModel+Detachable.swift"; sourceTree = "<group>"; };
 		2590B1F92510BB90003C0A03 /* VideoConference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoConference.swift; sourceTree = "<group>"; };
 		2590B1FB2510C9F2003C0A03 /* VideoConferenceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoConferenceViewController.swift; sourceTree = "<group>"; };
 		259286892473B1E00035EBA4 /* QuizReviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizReviewViewController.swift; sourceTree = "<group>"; };
@@ -1566,7 +1566,7 @@
 				25E435D4263ADBAA00243FD3 /* UserDefaults.swift */,
 				259ED9F8274E5B3100A87A71 /* Misc.swift */,
 				25520BBD2751093C001A58AB /* String.swift */,
-				2586782628ABB81700E149B5 /* Object.swift */,
+				2586782628ABB81700E149B5 /* DBModel+Detachable.swift */,
 				036654CC2A3D98930005BDDF /* UIInterfaceOrientationMask.swift */,
 			);
 			path = Extensions;
@@ -2044,7 +2044,7 @@
 				2F515DF81FF3B8050005D8A5 /* KeyboardLayoutConstraint.swift in Sources */,
 				D990C7F02B31731300B3ED4D /* AttemptQuestionTranslation.swift in Sources */,
 				2FC0F2E81F863AE80092BFDC /* User.swift in Sources */,
-				2586782728ABB81700E149B5 /* Object.swift in Sources */,
+				2586782728ABB81700E149B5 /* DBModel+Detachable.swift in Sources */,
 				257BB695246AB4C900524D2C /* QuizExamViewController.swift in Sources */,
 				2F70F4D71F9F1C3300D30755 /* BaseQuestionsListViewController.swift in Sources */,
 				2FC0F3101F863BA90092BFDC /* TestReportViewController.swift in Sources */,

--- a/ios-app/Extensions/DBModel+Detachable.swift
+++ b/ios-app/Extensions/DBModel+Detachable.swift
@@ -8,7 +8,7 @@ protocol DetachableObject: AnyObject {
     func detached() -> Self
 }
 
-extension Object: DetachableObject {
+extension DBModel: DetachableObject {
     func detached() -> Self {
         let detached = type(of: self).init()
         for property in objectSchema.properties {

--- a/ios-app/UI/BaseDBTableViewController.swift
+++ b/ios-app/UI/BaseDBTableViewController.swift
@@ -25,9 +25,8 @@
 
 import UIKit
 import ObjectMapper
-import RealmSwift
 
-class BaseDBTableViewController<T: Mappable>: TPBasePagedTableViewController<T> where T:Object {
+class BaseDBTableViewController<T: Mappable>: TPBasePagedTableViewController<T> where T:DBModel {
     
     var firstCallBack: Bool = true // On firstCallBack load modified items if items already exists
     

--- a/ios-app/UI/BaseDBTableViewControllerV2.swift
+++ b/ios-app/UI/BaseDBTableViewControllerV2.swift
@@ -8,10 +8,9 @@
 
 import UIKit
 import ObjectMapper
-import RealmSwift
 
 
-class BaseDBTableViewControllerV2<T: TestpressModel, L: TestpressModel>: BasePagedTableViewController<T, L> where L:Object {
+class BaseDBTableViewControllerV2<T: TestpressModel, L: TestpressModel>: BasePagedTableViewController<T, L> where L:DBModel {
     
     var firstCallBack: Bool = true // On firstCallBack load modified items if items already exists
     var networkItems : [L] = []

--- a/ios-app/UI/BaseDBViewController.swift
+++ b/ios-app/UI/BaseDBViewController.swift
@@ -9,10 +9,9 @@
 import Foundation
 import UIKit
 import ObjectMapper
-import RealmSwift
 
 
-class BaseDBViewController<T: Mappable>: UIViewController where T:Object{
+class BaseDBViewController<T: Mappable>: UIViewController where T:DBModel{
     var items = [T]()
     
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
- Replaced direct usage of Realm's Object with DBModel to eliminate Realm dependencies from the codebase.
- Moved detachment support from the Object extension to the DBModel class, ensuring the detachment functionality is preserved.