### PR TITLE
refactor: Modularize TPApiClient's Authentication Error Handling

### DIFF
--- a/ios-app.xcodeproj/project.pbxproj
+++ b/ios-app.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		0386961F2BF762DD00E36F8F /* IQKeyboardManagerSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 0386961E2BF762DD00E36F8F /* IQKeyboardManagerSwift */; };
 		038696222BF7635C00E36F8F /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 038696212BF7635C00E36F8F /* Kingfisher */; };
 		038696242BF7692900E36F8F /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 038696232BF7692900E36F8F /* PrivacyInfo.xcprivacy */; };
+		03A60F6D2CB3EAEF00079A7C /* AuthErrorHandlingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A60F6C2CB3EAEE00079A7C /* AuthErrorHandlingDelegate.swift */; };
 		03AFFB832C0076AE0015C029 /* ChapterContentDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AFFB822C0076AE0015C029 /* ChapterContentDetailViewModel.swift */; };
 		03D82DDB2BFCD84100678BBF /* VideoPlayerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D82DDA2BFCD84100678BBF /* VideoPlayerViewController.swift */; };
 		03D82DDD2BFDFF8000678BBF /* LiveStreamContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D82DDC2BFDFF8000678BBF /* LiveStreamContentViewController.swift */; };
@@ -494,6 +495,7 @@
 		038695FC2BF6095D00E36F8F /* DGCharts.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DGCharts.xcframework; path = Carthage/Build/DGCharts.xcframework; sourceTree = "<group>"; };
 		038695FF2BF6355E00E36F8F /* M3U8Parser.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = M3U8Parser.xcframework; path = Carthage/Build/M3U8Parser.xcframework; sourceTree = "<group>"; };
 		038696232BF7692900E36F8F /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		03A60F6C2CB3EAEE00079A7C /* AuthErrorHandlingDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthErrorHandlingDelegate.swift; sourceTree = "<group>"; };
 		03A91DEE2BFB7E2500B9E1C6 /* LiveStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveStream.swift; sourceTree = "<group>"; };
 		03AFFB822C0076AE0015C029 /* ChapterContentDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterContentDetailViewModel.swift; sourceTree = "<group>"; };
 		03D82DDA2BFCD84100678BBF /* VideoPlayerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlayerViewController.swift; sourceTree = "<group>"; };
@@ -1531,6 +1533,7 @@
 				2FC0F2ED1F863B080092BFDC /* TPBasePager.swift */,
 				2FC0F2EE1F863B080092BFDC /* TPEndpoint.swift */,
 				250629932265E8E900539FB2 /* LoginActivityPager.swift */,
+				03A60F6C2CB3EAEE00079A7C /* AuthErrorHandlingDelegate.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -2035,6 +2038,7 @@
 				2F412CC220219BC300B7F70C /* OrderedDictionary.swift in Sources */,
 				2F25D55C201EFE7B00C01CCE /* LeaderboardPager.swift in Sources */,
 				2FEDFF5A206CE7560002CF04 /* CategoryPager.swift in Sources */,
+				03A60F6D2CB3EAEF00079A7C /* AuthErrorHandlingDelegate.swift in Sources */,
 				25520BC327546AF9001A58AB /* DiscussionThreadDetailViewController.swift in Sources */,
 				8C04228F22AA3FD40015269B /* WebViewController.swift in Sources */,
 				25E435DD263ADCCF00243FD3 /* BaseSectionController.swift in Sources */,

--- a/ios-app/AppDelegate.swift
+++ b/ios-app/AppDelegate.swift
@@ -85,6 +85,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         handleFirstLaunch()
         TestpressCourse.shared.initialize()
         setupRootViewController()
+        setupAuthErrorHandlerOnApiClient()
         
         if let instituteSettings = fetchInstituteSettings() {
             setupSentry(instituteSettings: instituteSettings)
@@ -164,6 +165,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.rootViewController = viewController
         window?.makeKeyAndVisible()
+    }
+    
+    private func setupAuthErrorHandlerOnApiClient(){
+        TPApiClient.authErrorDelegate = AuthErrorHandler()
     }
 
     private func fetchInstituteSettings() -> InstituteSettings? {

--- a/ios-app/Network/AuthErrorHandlingDelegate.swift
+++ b/ios-app/Network/AuthErrorHandlingDelegate.swift
@@ -1,0 +1,16 @@
+//
+//  AuthErrorHandlingDelegate.swift
+//  ios-app
+//
+//  Created by Testpress on 07/10/24.
+//  Copyright © 2024 Testpress. All rights reserved.
+//
+
+import Foundation
+import CourseKit
+
+public protocol AuthErrorHandlingDelegate {
+    func handleUnauthenticatedError()
+    func handleMaxLoginLimitError()
+    func handleMultipleLoginRestrictionError(error: TPError)
+}


### PR DESCRIPTION
- Refactored TPApiClient to implement AuthErrorHandlingDelegate, allowing  integration with the app's view controllers without tight coupling.
- This change is essential before moving TPApiClient to a package, as it allows the API client to operate independently while still handling authentication errors appropriately. Without this refactoring, the direct dependency on view controllers would hinder the migration.

