### PR TITLE
refactor: Decouple navigation logic from specific view controllers

### DIFF
--- a/ios-app/UI/AccessCodeExamsViewController.swift
+++ b/ios-app/UI/AccessCodeExamsViewController.swift
@@ -26,7 +26,7 @@
 import UIKit
 import CourseKit
 
-class AccessCodeExamsViewController: TPBasePagedTableViewController<Exam> {
+class AccessCodeExamsViewController: TPBasePagedTableViewController<Exam>, TestEngineNavigationDelegate {
     
     let cellIdentifier = "ExamsTableViewCell"
     var accessCode: String!
@@ -66,4 +66,8 @@ class AccessCodeExamsViewController: TPBasePagedTableViewController<Exam> {
         dismiss(animated: true, completion: nil)
     }
     
+    func navigateBack() {
+        items.removeAll()
+        dismiss(animated: false, completion: nil)
+    }
 }

--- a/ios-app/UI/AttemptsListViewController.swift
+++ b/ios-app/UI/AttemptsListViewController.swift
@@ -254,3 +254,12 @@ class AttemptsListViewController: UIViewController, UITableViewDelegate, UITable
     }
 
 }
+
+extension AttemptsListViewController: TestEngineNavigationDelegate {
+    func navigateBack() {
+        dismiss(animated: false) {
+            self.attempts.removeAll()
+            self.loadAttemptsWithProgress(url: self.exam!.attemptsUrl)
+        }
+    }
+}

--- a/ios-app/UI/ContentDetailPageViewController.swift
+++ b/ios-app/UI/ContentDetailPageViewController.swift
@@ -26,7 +26,7 @@
 import UIKit
 import CourseKit
 
-class ContentDetailPageViewController: UIViewController, UIPageViewControllerDelegate {
+class ContentDetailPageViewController: UIViewController, UIPageViewControllerDelegate, TestEngineNavigationDelegate {
     
     @IBOutlet weak var navigationBar: UINavigationBar!
     @IBOutlet weak var contentsContainerView: UIView!
@@ -295,4 +295,9 @@ class ContentDetailPageViewController: UIViewController, UIPageViewControllerDel
         
     }
     
+    func navigateBack() {
+        dismiss(animated: false) {
+            self.updateCurrentExamContent()
+        }
+    }
 }

--- a/ios-app/UI/ExamsTabViewController.swift
+++ b/ios-app/UI/ExamsTabViewController.swift
@@ -27,7 +27,7 @@ import UIKit
 import XLPagerTabStrip
 import CourseKit
 
-class ExamsTabViewController: ButtonBarPagerTabStripViewController {
+class ExamsTabViewController: ButtonBarPagerTabStripViewController, TestEngineNavigationDelegate{
     
     @IBOutlet weak var tempButtonBarView: ButtonBarView!
     @IBOutlet weak var tempContainerView: UIScrollView!
@@ -72,4 +72,10 @@ class ExamsTabViewController: ButtonBarPagerTabStripViewController {
         UserHelper.showProfileDetails(self)
     }
     
+    func navigateBack() {
+        dismiss(animated: false) {
+            self.moveToViewController(at: 2, animated: true)
+            self.reloadPagerTabStripView()
+        }
+    }
 }

--- a/ios-app/UI/TestEngineViewController.swift
+++ b/ios-app/UI/TestEngineViewController.swift
@@ -804,44 +804,21 @@ extension TestEngineViewController: QuestionsPageViewDelegate {
     }
     
     func goBack() {
-        let presentingViewController = self.presentingViewController?.presentingViewController
-        
-        if let nvc =  presentingViewController as? UINavigationController,
-                let accessCodeExamsViewController =
-                    nvc.viewControllers.first as? AccessCodeExamsViewController {
-            
-            accessCodeExamsViewController.items.removeAll()
-            accessCodeExamsViewController.dismiss(animated: false, completion: nil)
-        } else if presentingViewController is UITabBarController {
-            let tabViewController =
-                presentingViewController?.children[0] as! ExamsTabViewController
-            
-            tabViewController.dismiss(animated: false, completion: {
-                if tabViewController.currentIndex != 2 {
-                    // Move to histroy tab
-                    tabViewController.moveToViewController(at: 2, animated: true)
-                }
-                // Refresh the list items
-                tabViewController.reloadPagerTabStripView()
-            })
-        } else if presentingViewController is AttemptsListViewController {
-            let attemptsListViewController = presentingViewController as! AttemptsListViewController
-            attemptsListViewController.dismiss(animated: false, completion: {
-                // Remove exsiting items
-                attemptsListViewController.attempts.removeAll()
-                // Load new attempts list with progress
-                attemptsListViewController.loadAttemptsWithProgress(url: self.exam!.attemptsUrl)
-            })
-        } else if presentingViewController is ContentDetailPageViewController {
-            
-            let contentDetailPageViewController =
-                presentingViewController as! ContentDetailPageViewController
-            
-            contentDetailPageViewController.dismiss(animated: false, completion: {
-                contentDetailPageViewController.updateCurrentExamContent()
-            })
+        var presentingViewController = self.presentingViewController?.presentingViewController
+
+        guard var presentingViewController = self.presentingViewController?.presentingViewController else {
+            dismiss(animated: true, completion: nil)
+            return
+        }
+
+        if presentingViewController is UITabBarController {
+            presentingViewController = presentingViewController.children.first!
+        }
+
+        if let navigatable = presentingViewController as? TestEngineNavigationDelegate {
+            navigatable.navigateBack()
         } else {
-            debugPrint(type(of: presentingViewController!))
+            debugPrint(type(of: presentingViewController))
             dismiss(animated: true, completion: nil)
         }
     }
@@ -854,3 +831,6 @@ extension TestEngineViewController: SlidingMenuDelegate {
     }
 }
 
+protocol TestEngineNavigationDelegate {
+    func navigateBack()
+}


### PR DESCRIPTION
- Refactored the `goBack` function in `TestEngineViewController` to remove direct dependencies on specific view controllers by introducing a new protocol to handle navigation logic and modified `goBack`, allowing more flexibility and reducing coupling.
- This refactor facilitates easier migration by decoupling the navigation behavior. With this change, we don't need to move tightly coupled controllers across modules.