### PR TITLE
fix: Exclude Sentry dependency for SPM integrations

### DIFF
--- a/CourseKit/Source/Network/Models/TPError.swift
+++ b/CourseKit/Source/Network/Models/TPError.swift
@@ -25,7 +25,9 @@
 
 import UIKit
 import Alamofire
+#if !SWIFT_PACKAGE
 import Sentry
+#endif
 
 
 public class TPError: Error {
@@ -102,6 +104,7 @@ public class TPError: Error {
     }
     
     public func logErrorToSentry() {
+        #if !SWIFT_PACKAGE
         let event = Event(level: .error)
         event.message = SentryMessage(formatted: self.message ?? "Some error occured")
         event.extra = [
@@ -112,6 +115,7 @@ public class TPError: Error {
         ]
         
         SentrySDK.capture(event: event)
+        #endif
     }
     
     public func getDisplayInfo() -> (image: UIImage, title: String, description: String) {

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,6 @@ let package = Package(
         "ObjectMapper",
         "Alamofire",
         "M3U8Parser",
-        .product(name: "Sentry", package: "sentry-cocoa"),
         "Kingfisher",
         "MarqueeLabel",
         .product(name:"SlideMenuController", package: "SlideMenuControllerSwift"), 


### PR DESCRIPTION
- Removed the Sentry dependency when the package is integrated via Swift Package Manager (SPM). 
- This change addresses conflicts that occur when the package is used in environments where Sentry is already present for error logging (e.g., Yukthi Flutter app). 
- Also, using Sentry in a package or third-party plugin can lead to multiple Sentry instances, which is not advised. For more details check refs.
- Sentry integration has been conditionally removed only for SPM setups. The package is still used internally within our app, where Sentry remains necessary, and our app does not have Sentry as a separate dependency.


References:
- Sentry Documentation: https://docs.sentry.io/platforms/
- Related Sentry Issue: getsentry/sentry-docs#3611