### PR TITLE
fix: Specify custom Realm file path to prevent schema conflicts

### DIFF
--- a/CourseKit/Source/Database/DBManager.swift
+++ b/CourseKit/Source/Database/DBManager.swift
@@ -37,9 +37,12 @@ public class DBConnection {
     }
     
     public static func configure(){
-        let config = Realm.Configuration(schemaVersion: 44)
-        Realm.Configuration.defaultConfiguration = config
-    }
+         var config = Realm.Configuration(schemaVersion: 1)
+         config.fileURL!.deleteLastPathComponent()
+         config.fileURL!.appendPathComponent("CourseKit")
+         config.fileURL!.appendPathExtension("realm")
+         Realm.Configuration.defaultConfiguration = config
+     }
     
     public func getDB() -> Realm {
         return database


### PR DESCRIPTION
- By default, the Realm SDK uses a default file path (`default.realm`) to store the Realm file. If an app using our package also has Realm as a dependency, both would attempt to use the same Realm file, leading to potential schema conflicts and improper migrations.
- Specifying a custom file path ensures that our package operates independently, avoiding conflicts with other Realm instances within the same app.
