### PR TITLE
fix: Enforce light mode in CourseKit ViewControllers

### DIFF
--- a/CourseKit/Source/UI/ViewControllers/AttachmentDetailViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/AttachmentDetailViewController.swift
@@ -30,7 +30,7 @@ import Alamofire
 import MarqueeLabel
 
 
-class AttachmentDetailViewController: UIViewController, URLSessionDownloadDelegate {
+class AttachmentDetailViewController: BaseUIViewController, URLSessionDownloadDelegate {
     
     @IBOutlet weak var scrollView: UIScrollView!
     @IBOutlet weak var contentView: UIView!

--- a/CourseKit/Source/UI/ViewControllers/AttemptsListViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/AttemptsListViewController.swift
@@ -25,7 +25,7 @@
 
 import UIKit
 
-public class AttemptsListViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
+public class AttemptsListViewController: BaseUIViewController, UITableViewDelegate, UITableViewDataSource {
     
     @IBOutlet weak var navigationBarItem: UINavigationItem!
     @IBOutlet weak var startButtonLayout: UIView!

--- a/CourseKit/Source/UI/ViewControllers/Base/BaseDBViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/Base/BaseDBViewController.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 import ObjectMapper
 
-open class BaseDBViewController<T: Mappable>: UIViewController where T:DBModel{
+open class BaseDBViewController<T: Mappable>: BaseUIViewController where T:DBModel{
     public var items = [T]()
     
     open override func viewWillAppear(_ animated: Bool) {

--- a/CourseKit/Source/UI/ViewControllers/Base/BaseTableViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/Base/BaseTableViewController.swift
@@ -43,6 +43,10 @@ open class BaseTableViewController<T: Mappable>: UITableViewController {
     open override func viewDidLoad() {
         super.viewDidLoad()
         
+        if #available(iOS 13.0, *) {
+            self.overrideUserInterfaceStyle = .light
+        }
+        
         activityIndicator = UIUtils.initActivityIndicator(parentView: self.view)
         activityIndicator?.center = CGPoint(x: view.center.x, y: view.center.y - 150)
         

--- a/CourseKit/Source/UI/ViewControllers/Base/BaseUIViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/Base/BaseUIViewController.swift
@@ -1,0 +1,20 @@
+//
+//  BaseUIViewController.swift
+//  CourseKit
+//
+//  Created by Testpress on 25/10/24.
+//  Copyright © 2024 Testpress. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+open class BaseUIViewController: UIViewController {
+    open override func viewDidLoad() {
+        super.viewDidLoad()
+
+        if #available(iOS 13.0, *) {
+            self.overrideUserInterfaceStyle = .light
+        }
+    }
+}

--- a/CourseKit/Source/UI/ViewControllers/Base/BaseWebViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/Base/BaseWebViewController.swift
@@ -26,7 +26,7 @@
 import UIKit
 import WebKit
 
-open class BaseWebViewController: UIViewController {
+open class BaseWebViewController: BaseUIViewController {
 
     public var webView: WKWebView!
     public var parentView: UIView!

--- a/CourseKit/Source/UI/ViewControllers/BaseQuestionsPageViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/BaseQuestionsPageViewController.swift
@@ -31,7 +31,7 @@ import UIKit
     func goBack()
 }
 
-class BaseQuestionsPageViewController: UIViewController, UIPageViewControllerDelegate {
+class BaseQuestionsPageViewController: BaseUIViewController, UIPageViewControllerDelegate {
     
     @IBOutlet weak var questionsContainerView: UIView!
     @IBOutlet weak var prevArrow: UIImageView!

--- a/CourseKit/Source/UI/ViewControllers/BaseQuestionsSlidingViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/BaseQuestionsSlidingViewController.swift
@@ -47,6 +47,14 @@ class BaseQuestionsSlidingViewController: SlideMenuController {
     var questionsSlidingMenuDelegate: QuestionsSlidingMenuDelegate!
     var panelOpened: Bool = false
     
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        if #available(iOS 13.0, *) {
+            self.overrideUserInterfaceStyle = .light
+        }
+    }
+    
     override func awakeFromNib() {
         let mainViewController = self.mainViewController as! BaseQuestionsPageViewController
         let leftViewController = self.leftViewController as! BaseQuestionsListViewController

--- a/CourseKit/Source/UI/ViewControllers/BookmarksDetailPageViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/BookmarksDetailPageViewController.swift
@@ -25,7 +25,7 @@
 
 import UIKit
 
-class BookmarksDetailPageViewController: UIViewController, UIPageViewControllerDelegate {
+class BookmarksDetailPageViewController: BaseUIViewController, UIPageViewControllerDelegate {
     
     @IBOutlet weak var questionsContainerView: UIView!
     @IBOutlet weak var prevArrow: UIImageView!

--- a/CourseKit/Source/UI/ViewControllers/ContentDetailPageViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/ContentDetailPageViewController.swift
@@ -25,7 +25,7 @@
 
 import UIKit
 
-public class ContentDetailPageViewController: UIViewController, UIPageViewControllerDelegate {
+public class ContentDetailPageViewController: BaseUIViewController, UIPageViewControllerDelegate {
     
     @IBOutlet weak var navigationBar: UINavigationBar!
     @IBOutlet weak var contentsContainerView: UIView!

--- a/CourseKit/Source/UI/ViewControllers/LiveStreamContentViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/LiveStreamContentViewController.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-class LiveStreamContentViewController: UIViewController {
+class LiveStreamContentViewController: BaseUIViewController {
     var content: Content!
     var playerViewController: VideoPlayerViewController!
     var reloadTimer: Timer?

--- a/CourseKit/Source/UI/ViewControllers/LoadingViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/LoadingViewController.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-class LoadingViewController: UIViewController {
+class LoadingViewController: BaseUIViewController {
     private lazy var activityIndicator = UIActivityIndicatorView(style: .gray)
     
     override func viewDidLoad() {

--- a/CourseKit/Source/UI/ViewControllers/OverallSubjectAnalyticsViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/OverallSubjectAnalyticsViewController.swift
@@ -27,7 +27,7 @@ import DGCharts
 import UIKit
 import XLPagerTabStrip
 
-class OverallSubjectAnalyticsViewController: UIViewController {
+class OverallSubjectAnalyticsViewController: BaseUIViewController {
     
     @IBOutlet weak var chartView: HorizontalBarChartView!
     @IBOutlet weak var scrollView: UIScrollView!

--- a/CourseKit/Source/UI/ViewControllers/PDFViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/PDFViewController.swift
@@ -3,7 +3,7 @@ import PDFKit
 import MarqueeLabel
 
 
-class PDFViewController: UIViewController {
+class PDFViewController: BaseUIViewController {
     var pdfDocument: PDFDocument?
     @IBOutlet var pdfView: PDFView!
     @IBOutlet weak var navigationBarItem: UINavigationItem!

--- a/CourseKit/Source/UI/ViewControllers/QuizExamViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/QuizExamViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class QuizExamViewController: UIViewController {
+class QuizExamViewController: BaseUIViewController {
     var contentAttempt: ContentAttempt?
     var exam: Exam?
     var attempt: Attempt?

--- a/CourseKit/Source/UI/ViewControllers/ShareToUnlockViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/ShareToUnlockViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class ShareToUnlockViewController: UIViewController {
+class ShareToUnlockViewController: BaseUIViewController {
     var shareText: String = ""
     var onShareCompletion: (() -> Void)?
     

--- a/CourseKit/Source/UI/ViewControllers/StartExamScreenViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/StartExamScreenViewController.swift
@@ -26,7 +26,7 @@
 import SlideMenuController
 import UIKit
 
-public class StartExamScreenViewController: UIViewController {
+public class StartExamScreenViewController: BaseUIViewController {
     
     static let REGULAR_ATTEMPT = 0
     static let QUIZ_ATTEMPT = 1

--- a/CourseKit/Source/UI/ViewControllers/StartQuizExamViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/StartQuizExamViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class StartQuizExamViewController: UIViewController {
+class StartQuizExamViewController: BaseUIViewController {
     @IBOutlet weak var examTitle: UILabel!
     @IBOutlet weak var questionsCount: UILabel!
     @IBOutlet weak var startEndDate: UILabel!

--- a/CourseKit/Source/UI/ViewControllers/TestReportViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/TestReportViewController.swift
@@ -25,7 +25,7 @@
 
 import UIKit
 
-class TestReportViewController: UIViewController {
+class TestReportViewController: BaseUIViewController {
 
     @IBOutlet weak var rankLayout: UIView!
     @IBOutlet weak var examTitle: UILabel!

--- a/CourseKit/Source/UI/ViewControllers/TimeAnalyticsTableViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/TimeAnalyticsTableViewController.swift
@@ -27,7 +27,7 @@ import LUExpandableTableView
 import UIKit
 import WebKit
 
-class TimeAnalyticsTableViewController: UIViewController {
+class TimeAnalyticsTableViewController: BaseUIViewController {
     
     @IBOutlet var tableView: LUExpandableTableView!
     @IBOutlet weak var contentView: UIView!

--- a/CourseKit/Source/UI/ViewControllers/TrophiesAchievedViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/TrophiesAchievedViewController.swift
@@ -25,7 +25,7 @@
 
 import UIKit
 
-class TrophiesAchievedViewController: UIViewController {
+class TrophiesAchievedViewController: BaseUIViewController {
     
     @IBOutlet weak var scrollView: UIScrollView!
     @IBOutlet weak var contentViewHeightConstraint: NSLayoutConstraint!

--- a/CourseKit/Source/UI/ViewControllers/VideoConferenceViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/VideoConferenceViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class VideoConferenceViewController: UIViewController {
+class VideoConferenceViewController: BaseUIViewController {
     var content: Content!
     @IBOutlet weak var titleView: UILabel!
     @IBOutlet weak var startTime: UILabel!

--- a/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
@@ -32,7 +32,7 @@ import Alamofire
 import TTGSnackbar
 
 
-class VideoContentViewController: UIViewController,UITableViewDelegate, UITableViewDataSource, UITextViewDelegate {
+class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITableViewDataSource, UITextViewDelegate {
     var content: Content!
     var contents: [Content]!
     var playerViewController: VideoPlayerViewController!

--- a/CourseKit/Source/UI/ViewControllers/VideoPlayerViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/VideoPlayerViewController.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-class VideoPlayerViewController: UIViewController {
+class VideoPlayerViewController: BaseUIViewController {
     var playerView: VideoPlayerView!
     var warningLabel: UILabel!
     var warningView: UIView!

--- a/ios-app.xcodeproj/project.pbxproj
+++ b/ios-app.xcodeproj/project.pbxproj
@@ -302,6 +302,7 @@
 		03E4AFD22CAFD22100ECC34D /* DashboardSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E4AFD12CAFD22100ECC34D /* DashboardSection.swift */; };
 		03E4AFD42CAFE63900ECC34D /* KeychainTokenItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FC0F27E1F861A3E0092BFDC /* KeychainTokenItem.swift */; };
 		03E4AFD62CAFE6A900ECC34D /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E4AFD52CAFE6A900ECC34D /* Constants.swift */; };
+		03FF48292CCB79D9008CED9D /* BaseUIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FF48282CCB79D9008CED9D /* BaseUIViewController.swift */; };
 		2503DF50263C01E8003226AD /* CarouselSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2503DF4F263C01E8003226AD /* CarouselSectionController.swift */; };
 		2503DF53263C0296003226AD /* BannerSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2503DF52263C0296003226AD /* BannerSectionController.swift */; };
 		2503DF57263C02C3003226AD /* BannerAdViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2503DF55263C02C3003226AD /* BannerAdViewCell.swift */; };
@@ -507,6 +508,7 @@
 		03D82DDC2BFDFF8000678BBF /* LiveStreamContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveStreamContentViewController.swift; sourceTree = "<group>"; };
 		03E4AFD12CAFD22100ECC34D /* DashboardSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardSection.swift; sourceTree = "<group>"; };
 		03E4AFD52CAFE6A900ECC34D /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		03FF48282CCB79D9008CED9D /* BaseUIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseUIViewController.swift; sourceTree = "<group>"; };
 		1825F5FC212E8BF900AC25E5 /* AttemptSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttemptSection.swift; sourceTree = "<group>"; };
 		1825F5FE212E920C00AC25E5 /* PlainDropDown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainDropDown.swift; sourceTree = "<group>"; };
 		18F25D26212FDB7000097425 /* LockableSectionDropDownCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LockableSectionDropDownCell.xib; sourceTree = "<group>"; };
@@ -1064,6 +1066,7 @@
 				2FE2906F1F8CF8E7004D7574 /* BaseWebViewController.swift */,
 				2FC0F29A1F861A860092BFDC /* TPBasePagedTableViewController.swift */,
 				2FC0F2871F861A860092BFDC /* EmptyView.swift */,
+				03FF48282CCB79D9008CED9D /* BaseUIViewController.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -2127,6 +2130,7 @@
 				038CB2952CBD278600164127 /* ChapterCollectionViewCell.swift in Sources */,
 				03CD0D412CB94A8C00E17218 /* VideoPlayerControlsView.swift in Sources */,
 				03CD0C652CB7C3CE00E17218 /* String.swift in Sources */,
+				03FF48292CCB79D9008CED9D /* BaseUIViewController.swift in Sources */,
 				03E4AF252CAEDE3D00ECC34D /* DBModel+Detachable.swift in Sources */,
 				03E4AFB12CAFCF6F00ECC34D /* ApiResponse.swift in Sources */,
 				038CB29B2CBD278600164127 /* BookmarksSlidingViewController.swift in Sources */,


### PR DESCRIPTION
- CourseKit view controllers did not support dark mode, which caused UI degradation when integrated into Flutter apps with dark themes.
- Introduced a BaseUIViewController class that enforces light mode by setting overrideUserInterfaceStyle to .light for all inheriting view controllers.
- Updated existing CourseKit view controllers to inherit from BaseUIViewController, ensuring a consistent light appearance.