### PR TITLE
fix: Support video playback from offline downloads view

### DIFF
--- a/CourseKit/Source/UI/ViewControllers/OfflineDownloadTableViewCell.swift
+++ b/CourseKit/Source/UI/ViewControllers/OfflineDownloadTableViewCell.swift
@@ -18,6 +18,7 @@ class OfflineDownloadTableViewCell: UITableViewCell {
     @IBOutlet weak var progressView: UIProgressView!
     @IBOutlet weak var containerCell: UIView!
     var offlineAsset : OfflineAsset?
+    weak var delegate: OfflineDownloadTableViewCellDelegate?
     
     func configure(with asset: OfflineAsset) {
         offlineAsset = asset
@@ -55,6 +56,10 @@ class OfflineDownloadTableViewCell: UITableViewCell {
     }
     
     @objc func onItemClick() {
-        // Open Player view
+        delegate?.didTapItem(for: offlineAsset!.assetId)
     }
+}
+
+protocol OfflineDownloadTableViewCellDelegate: AnyObject {
+    func didTapItem(for assetId: String)
 }


### PR DESCRIPTION
This update adds the ability to play downloaded video content directly from the `OfflineDownloadsViewController`. A delegate pattern is implemented between `OfflineDownloadTableViewCell` and `OfflineDownloadsViewController` to handle cell interactions, allowing users to tap on an offline item and initiate playback in a full-screen player view.