### PR TITLE
refactor: Offline Downloads View Controller Initialization

### DIFF
--- a/CourseKit/Source/TestpressCourse.swift
+++ b/CourseKit/Source/TestpressCourse.swift
@@ -50,10 +50,6 @@ public class TestpressCourse {
     public func getMyCoursesViewController() -> CoursesTableViewController? {
         return instantiateViewController(withIdentifier: "CoursesTableViewController")
     }
-    
-    public func getOfflineDownloadsViewController() -> OfflineDownloadsViewController? {
-        return instantiateViewController(withIdentifier: Constants.OFFLINE_DOWNLOADS_VIEW_CONTROLLERS)
-    }
 
     public func getContentDetailViewController(contentId: Int) -> ContentDetailPageViewController? {
         guard let detailViewController: ContentDetailPageViewController = instantiateViewController(withIdentifier: Constants.CONTENT_DETAIL_PAGE_VIEW_CONTROLLER) else {
@@ -80,7 +76,7 @@ public class TestpressCourse {
     }
     
     public func getMyDownloadsViewController() -> UIViewController? {
-        return instantiateViewController(withIdentifier: "ComingSoonViewController")
+        return instantiateViewController(withIdentifier: Constants.OFFLINE_DOWNLOADS_VIEW_CONTROLLERS)
     }
 
     private func instantiateViewController<T>(withIdentifier identifier: String) -> T? {

--- a/ios-app/UI/OfflineDownloadsTabController.swift
+++ b/ios-app/UI/OfflineDownloadsTabController.swift
@@ -22,7 +22,7 @@ public class OfflineDownloadsTabController: UINavigationController {
     }
 
     private func setupOfflineDownloadsTab() {
-        let viewController = TestpressCourse.shared.getOfflineDownloadsViewController()
+        let viewController = TestpressCourse.shared.getMyDownloadsViewController()
         viewController?.title = "Offline Downloads"
         viewController?.tabBarItem.image = Images.LearnNavBarIcon.image
         


### PR DESCRIPTION
- Removed the `getOfflineDownloadsViewController()` method from TestpressCourse class.
- Replaced it with the `getMyDownloadsViewController()` method to provide access to the "Offline Downloads" screen.