### PR TITLE
fix: App crash while accessing content from dashboard section

### DIFF
--- a/ios-app/UI/Dashboard/SectionControllers/ChapterContentSectionController.swift
+++ b/ios-app/UI/Dashboard/SectionControllers/ChapterContentSectionController.swift
@@ -40,11 +40,7 @@ class ChapterContentSectionController: ListSectionController {
             withIdentifier: Constants.CONTENT_DETAIL_PAGE_VIEW_CONTROLLER)
             as! ContentDetailPageViewController
         
-        let content = dashboardData?.getContent(id: contentId!)
-        contentDetailViewController.contents = [content!
-        ]
-        contentDetailViewController.title = content?.name
-        contentDetailViewController.position = 0
+        contentDetailViewController.contentId = contentId!
         viewController?.present(contentDetailViewController, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
- App crashes when accessing content from the dashboard section due to incomplete content object relationships being passed to the content detail page view controller.
- The issue occurred because the dashboard response contains partial content data, and related objects were not available.
- Fixed by passing only contentId and letting the content detail page view controller fetch complete content data using its existing content loading logic.
