### PR TITLE
fix: Optimize chapter fetching to load only required chapters

### DIFF
--- a/CourseKit/Source/Database/DBManager.swift
+++ b/CourseKit/Source/Database/DBManager.swift
@@ -109,6 +109,21 @@ public class DBManager<T: Object> {
         )
     }
     
+    public func getItemsFromDB(
+        filteredBy filters: [String],
+        byKeyPath: String,
+        ascending: Bool = true
+    ) -> [T] {
+        var results = getResultsFromDB()
+        
+        filters.forEach { filter in
+            results = results.filter(filter)
+        }
+        
+        results = results.sorted(byKeyPath: byKeyPath, ascending: ascending)
+        return Array(results)
+    }
+    
     public func getSortedItemsFromDB(byKeyPath: String, ascending: Bool = true) -> [T] {
         return Array(getResultsFromDB().sorted(byKeyPath: byKeyPath, ascending: ascending))
     }

--- a/CourseKit/Source/Database/DBManager.swift
+++ b/CourseKit/Source/Database/DBManager.swift
@@ -96,20 +96,6 @@ public class DBManager<T: Object> {
     }
     
     public func getItemsFromDB(
-        filteredBy firstFilter: String,
-        and secondFilter: String,
-        byKeyPath: String,
-        ascending: Bool = true
-    ) -> [T] {
-        return Array(
-            getResultsFromDB()
-                .filter(firstFilter)
-                .filter(secondFilter)
-                .sorted(byKeyPath: byKeyPath, ascending: ascending)
-        )
-    }
-    
-    public func getItemsFromDB(
         filteredBy filters: [String],
         byKeyPath: String,
         ascending: Bool = true

--- a/CourseKit/Source/Database/DBManager.swift
+++ b/CourseKit/Source/Database/DBManager.swift
@@ -95,6 +95,20 @@ public class DBManager<T: Object> {
             .sorted(byKeyPath: byKeyPath, ascending: ascending))
     }
     
+    public func getItemsFromDB(
+        filteredBy firstFilter: String,
+        and secondFilter: String,
+        byKeyPath: String,
+        ascending: Bool = true
+    ) -> [T] {
+        return Array(
+            getResultsFromDB()
+                .filter(firstFilter)
+                .filter(secondFilter)
+                .sorted(byKeyPath: byKeyPath, ascending: ascending)
+        )
+    }
+    
     public func getSortedItemsFromDB(byKeyPath: String, ascending: Bool = true) -> [T] {
         return Array(getResultsFromDB().sorted(byKeyPath: byKeyPath, ascending: ascending))
     }

--- a/CourseKit/Source/Network/Pagers/ChapterPager.swift
+++ b/CourseKit/Source/Network/Pagers/ChapterPager.swift
@@ -31,14 +31,15 @@ public class ChapterPager: TPBasePager<Chapter> {
     public let url: String
     public let parentId: Int?
     
-    public init(coursesUrl: String, parentId: Int?) {
-        self.url = coursesUrl + TPEndpoint.getChapters.urlPath
+    public init(courseId: Int, parentId: Int?) {
+        self.url = TestpressCourse.shared.baseURL + TPEndpoint.getCourses.urlPath + "\(courseId)/" + TPEndpoint.getChapters.urlPath
         self.parentId = parentId
         super.init()
     }
     
     public override func getItems(page: Int) {
         queryParams.updateValue(String(page), forKey: Constants.PAGE)
+        queryParams[Constants.PAGE] = parentId != nil ? String(parentId!) : "null"
         TPApiClient.getListItems(
             endpointProvider: TPEndpointProvider(.getChapters, url: url, queryParams: queryParams),
             completion: resonseHandler!,

--- a/CourseKit/Source/Network/Pagers/ChapterPager.swift
+++ b/CourseKit/Source/Network/Pagers/ChapterPager.swift
@@ -32,14 +32,14 @@ public class ChapterPager: TPBasePager<Chapter> {
     public let parentId: Int?
     
     public init(courseId: Int, parentId: Int?) {
-        self.url = TestpressCourse.shared.baseURL + TPEndpoint.getCourses.urlPath + "\(courseId)/" + TPEndpoint.getChapters.urlPath
+        self.url = TPEndpointProvider.getCourseDetailUrl(courseId: courseId) + TPEndpoint.getChapters.urlPath
         self.parentId = parentId
         super.init()
     }
     
     public override func getItems(page: Int) {
         queryParams.updateValue(String(page), forKey: Constants.PAGE)
-        queryParams[Constants.PAGE] = parentId != nil ? String(parentId!) : "null"
+        queryParams[Constants.PARENT] = parentId != nil ? String(parentId!) : "null"
         TPApiClient.getListItems(
             endpointProvider: TPEndpointProvider(.getChapters, url: url, queryParams: queryParams),
             completion: resonseHandler!,

--- a/CourseKit/Source/TestpressCourse.swift
+++ b/CourseKit/Source/TestpressCourse.swift
@@ -78,7 +78,6 @@ public class TestpressCourse {
         }
         
         detailViewController.courseId = courseId
-        detailViewController.baseUrl = TPEndpointProvider.getCourseDetailUrl(courseId: courseId)
         detailViewController.allowCustomTestGeneration = false
         return detailViewController
     }

--- a/CourseKit/Source/UI/ViewControllers/ChapterCollectionViewCell.swift
+++ b/CourseKit/Source/UI/ViewControllers/ChapterCollectionViewCell.swift
@@ -54,7 +54,6 @@ class ChapterCollectionViewCell: UICollectionViewCell {
             let chapterViewController = storyboard.instantiateViewController(withIdentifier:
                 Constants.CHAPTERS_VIEW_CONTROLLER) as! ChaptersViewController
             chapterViewController.courseId = chapter.courseId
-            chapterViewController.baseUrl = chapter.url
             chapterViewController.parentId = chapter.id
             chapterViewController.title = chapter.name
             viewController = chapterViewController

--- a/CourseKit/Source/UI/ViewControllers/ChaptersViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/ChaptersViewController.swift
@@ -125,10 +125,7 @@ BaseDBViewController<Chapter> {
                 self.items = Array(items!.values)
                 var chaptersFromDB = [] as [Chapter]
                 let parentIdFilter = self.parentId ?? 0
-                chaptersFromDB = DBManager<Chapter>().getItemsFromDB(
-                    filteredBy: [String(format: "courseId==%d", self.courseId), String(format: "parentId==%d", parentIdFilter)],
-                    byKeyPath: "order"
-                )
+                chaptersFromDB = self.getChaptersFromDB(courseId: self.courseId, parentId: parentIdFilter)
                 DBManager<Chapter>().deleteFromDb(objects: chaptersFromDB)
                 DBManager<Chapter>().addData(objects: items!.values)
                 if self.items.count == 0 {
@@ -142,6 +139,16 @@ BaseDBViewController<Chapter> {
                 self.loadingItems = false
             }
         })
+    }
+    
+    func getChaptersFromDB(courseId: Int, parentId: Int) -> [Chapter] {
+        return DBManager<Chapter>().getItemsFromDB(
+            filteredBy: [
+                String(format: "courseId==%d", courseId),
+                String(format: "parentId==%d", parentId)
+            ],
+            byKeyPath: "order"
+        )
     }
     
     func handleError(_ error: TPError) {

--- a/CourseKit/Source/UI/ViewControllers/ChaptersViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/ChaptersViewController.swift
@@ -123,9 +123,8 @@ BaseDBViewController<Chapter> {
                 self.loadItems()
             } else {
                 self.items = Array(items!.values)
-                var chaptersFromDB = [] as [Chapter]
                 let parentIdFilter = self.parentId ?? 0
-                chaptersFromDB = self.getChaptersFromDB(courseId: self.courseId, parentId: parentIdFilter)
+                let chaptersFromDB = self.getChaptersFromDB(courseId: self.courseId, parentId: parentIdFilter)
                 DBManager<Chapter>().deleteFromDb(objects: chaptersFromDB)
                 DBManager<Chapter>().addData(objects: items!.values)
                 if self.items.count == 0 {

--- a/CourseKit/Source/UI/ViewControllers/ChaptersViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/ChaptersViewController.swift
@@ -35,7 +35,6 @@ BaseDBViewController<Chapter> {
     var emptyView: EmptyView!
     var pager: ChapterPager!
     public var loadingItems: Bool = false
-    public var baseUrl: String!
     public var courseId: Int!
     public var parentId: Int? = nil
     public var firstCallback: Bool = true
@@ -46,7 +45,7 @@ BaseDBViewController<Chapter> {
         super.viewDidLoad()
         
         navigationItemBar.title = title
-        pager = ChapterPager(coursesUrl: baseUrl, parentId: parentId)
+        pager = ChapterPager(courseId: courseId, parentId: parentId)
         activityIndicator = UIUtils.initActivityIndicator(parentView: collectionView)
         activityIndicator?.center = CGPoint(x: view.center.x, y: view.center.y - 50)
         instituteSettings = DBManager<InstituteSettings>().getResultsFromDB()[0]
@@ -124,7 +123,12 @@ BaseDBViewController<Chapter> {
                 self.loadItems()
             } else {
                 self.items = Array(items!.values)
-                let chaptersFromDB = DBManager<Chapter>().getItemsFromDB(filteredBy: String(format: "courseId==%d", self.courseId), byKeyPath: "order")
+                var chaptersFromDB = [] as [Chapter]
+                if (self.parentId != nil){
+                    chaptersFromDB = DBManager<Chapter>().getItemsFromDB(filteredBy: String(format: "courseId==%d", self.courseId), and: String(format: "parentId==%d", self.parentId!), byKeyPath: "order")
+                } else {
+                    chaptersFromDB = DBManager<Chapter>().getItemsFromDB(filteredBy: String(format: "courseId==%d", self.courseId), and: String(format: "parentId==%d", 0), byKeyPath: "order")
+                }
                 DBManager<Chapter>().deleteFromDb(objects: chaptersFromDB)
                 DBManager<Chapter>().addData(objects: items!.values)
                 if self.items.count == 0 {

--- a/CourseKit/Source/UI/ViewControllers/ChaptersViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/ChaptersViewController.swift
@@ -124,11 +124,11 @@ BaseDBViewController<Chapter> {
             } else {
                 self.items = Array(items!.values)
                 var chaptersFromDB = [] as [Chapter]
-                if (self.parentId != nil){
-                    chaptersFromDB = DBManager<Chapter>().getItemsFromDB(filteredBy: String(format: "courseId==%d", self.courseId), and: String(format: "parentId==%d", self.parentId!), byKeyPath: "order")
-                } else {
-                    chaptersFromDB = DBManager<Chapter>().getItemsFromDB(filteredBy: String(format: "courseId==%d", self.courseId), and: String(format: "parentId==%d", 0), byKeyPath: "order")
-                }
+                let parentIdFilter = self.parentId ?? 0
+                chaptersFromDB = DBManager<Chapter>().getItemsFromDB(
+                    filteredBy: [String(format: "courseId==%d", self.courseId), String(format: "parentId==%d", parentIdFilter)],
+                    byKeyPath: "order"
+                )
                 DBManager<Chapter>().deleteFromDb(objects: chaptersFromDB)
                 DBManager<Chapter>().addData(objects: items!.values)
                 if self.items.count == 0 {

--- a/CourseKit/Source/UI/ViewControllers/CourseTableViewCell.swift
+++ b/CourseKit/Source/UI/ViewControllers/CourseTableViewCell.swift
@@ -114,7 +114,6 @@ class CourseTableViewCell: UITableViewCell {
                 Constants.CHAPTERS_VIEW_CONTROLLER) as! ChaptersViewController
 
             chaptersViewController.courseId = course.id
-            chaptersViewController.baseUrl = course.url
             chaptersViewController.title = course.title
             chaptersViewController.allowCustomTestGeneration = course.allowCustomTestGeneration
             viewController = chaptersViewController


### PR DESCRIPTION
- This PR addresses the inefficiency in fetching chapters for the chapter list. Previously, all chapters were fetched, and only the required root or child chapters were displayed to the user. This led to performance issues, especially with large datasets.
- Now fetching only the necessary chapters (root or child) from the database or API.
- The ChapterPager initialization is updated to pass only the relevant course ID and parent ID.
- The database fetch for chapters is now filtered by both courseId and parentId, ensuring only the necessary chapters are retrieved from the local database.