### PR TITLE
refactor: Move app-specific constants from SDK to app module

### DIFF
--- a/CourseKit/Source/Utils/Constants.swift
+++ b/CourseKit/Source/Utils/Constants.swift
@@ -9,11 +9,6 @@
 import Foundation
 
 public struct Constants {
-    public static let APP_APPLE_ID = "1434052944"
-    
-    public static let APP_SHARE_MESSAGE = "Good app to prepare for online exams. Get it at http://itunes.apple.com/app/id" + APP_APPLE_ID
-    
-    public static let APP_STORE_LINK = "itms-apps://itunes.apple.com/app/id" + APP_APPLE_ID
     
     public static let KEYCHAIN_SERVICE_NAME = Bundle.main.bundleIdentifier!
     

--- a/ios-app/UI/MoreOptionsViewController.swift
+++ b/ios-app/UI/MoreOptionsViewController.swift
@@ -29,7 +29,7 @@ import CourseKit
 class MoreOptionsViewController: UIViewController {
     
     @IBAction func rateUs() {
-        if let url = URL(string: Constants.APP_STORE_LINK),
+        if let url = URL(string: AppConstants.APP_STORE_LINK),
             UIApplication.shared.canOpenURL(url) {
             if #available(iOS 10, *) {
                 UIApplication.shared.open(url, options: [:])
@@ -40,7 +40,7 @@ class MoreOptionsViewController: UIViewController {
     }
     
     @IBAction func shareApp() {
-        let textToShare = [ Constants.APP_SHARE_MESSAGE ]
+        let textToShare = [ AppConstants.APP_SHARE_MESSAGE ]
         let activityViewController =
             UIActivityViewController(activityItems: textToShare, applicationActivities: nil)
         

--- a/ios-app/UI/ProfileViewController.swift
+++ b/ios-app/UI/ProfileViewController.swift
@@ -176,7 +176,7 @@ class ProfileViewController: UIViewController {
     }
     
     @IBAction func rateUs() {
-        if let url = URL(string: Constants.APP_STORE_LINK),
+        if let url = URL(string: AppConstants.APP_STORE_LINK),
             UIApplication.shared.canOpenURL(url) {
             if #available(iOS 10, *) {
                 UIApplication.shared.open(url, options: [:])
@@ -187,7 +187,7 @@ class ProfileViewController: UIViewController {
     }
     
     @IBAction func shareApp() {
-        let textToShare = [ Constants.APP_SHARE_MESSAGE ]
+        let textToShare = [ AppConstants.APP_SHARE_MESSAGE ]
         let activityViewController =
             UIActivityViewController(activityItems: textToShare, applicationActivities: nil)
         

--- a/ios-app/Utils/AppConstants.swift
+++ b/ios-app/Utils/AppConstants.swift
@@ -9,5 +9,9 @@
 import Foundation
 
 public struct AppConstants {
+    
     public static let SUBDOMAIN = "lmsdemo"
+    public static let APP_APPLE_ID = "1434052944"
+    public static let APP_SHARE_MESSAGE = "Good app to prepare for online exams. Get it at http://itunes.apple.com/app/id" + APP_APPLE_ID
+    public static let APP_STORE_LINK = "itms-apps://itunes.apple.com/app/id" + APP_APPLE_ID
 }


### PR DESCRIPTION
- This PR refactors the application-specific constants (APP_APPLE_ID, APP_SHARE_MESSAGE, and APP_STORE_LINK) by moving them from the SDK's Constants struct to the app module's AppConstants struct.
- Separates SDK constants from app-specific configurations to enhance modularity and reusability.
- Ensures that app-specific constants are maintained within the app module, making future updates or customizations easier.