### PR TITLE
refactor: Move primary color constant to AppConstants for centralized configuration

### DIFF
--- a/ios-app/AppDelegate.swift
+++ b/ios-app/AppDelegate.swift
@@ -76,7 +76,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        TestpressCourse.shared.initialize(subdomain: AppConstants.SUBDOMAIN, primaryColor: Colors.DODGERBLUE)
+        TestpressCourse.shared.initialize(subdomain: AppConstants.SUBDOMAIN, primaryColor: AppConstants.PRIMARY_COLOR)
         registerForNotifications(application)
         configureFirebase()
         customizeAppearance()

--- a/ios-app/UI/LoginViewController.swift
+++ b/ios-app/UI/LoginViewController.swift
@@ -141,7 +141,7 @@ class LoginViewController: BaseTextFieldViewController {
                     
                     // Save the password for the new item
                     try passwordItem.savePassword(token)
-                    TestpressCourse.shared.initialize(withToken: token, subdomain: AppConstants.SUBDOMAIN, primaryColor: Colors.DODGERBLUE)
+                    TestpressCourse.shared.initialize(withToken: token, subdomain: AppConstants.SUBDOMAIN, primaryColor: AppConstants.PRIMARY_COLOR)
                 } catch {
                     fatalError("Error updating keychain - \(error)")
                 }

--- a/ios-app/Utils/AppConstants.swift
+++ b/ios-app/Utils/AppConstants.swift
@@ -14,4 +14,5 @@ public struct AppConstants {
     public static let APP_APPLE_ID = "1434052944"
     public static let APP_SHARE_MESSAGE = "Good app to prepare for online exams. Get it at http://itunes.apple.com/app/id" + APP_APPLE_ID
     public static let APP_STORE_LINK = "itms-apps://itunes.apple.com/app/id" + APP_APPLE_ID
+    public static let PRIMARY_COLOR = "#2196F3"
 }


### PR DESCRIPTION
Ensures the primary color is defined in a single location, making it easier to update or customize the app's theme.