### PR TITLE
fix: Add Doubts screen at index 3 or append if fewer view controllers

### DIFF
--- a/ios-app/UI/MainMenuTabViewController.swift
+++ b/ios-app/UI/MainMenuTabViewController.swift
@@ -68,7 +68,7 @@ class MainMenuTabViewController: UITabBarController {
             viewControllers?.remove(at: 1)
         }
         
-        addDoubtsWebViewController(to: &viewControllers)
+        addDoubtsWebViewController()
         
         if (UserDefaults.standard.string(forKey: Constants.REGISTER_DEVICE_TOKEN) == "true") {
             let deviceToken = UserDefaults.standard.string(forKey: Constants.DEVICE_TOKEN)
@@ -109,7 +109,7 @@ class MainMenuTabViewController: UITabBarController {
         SFMCSdk.initializeSdk(ConfigBuilder().setPush(config: mobilePushConfiguration, onCompletion: completionHandler).build())
     }
     
-    private func addDoubtsWebViewController(to viewControllers: inout [UIViewController]?) {
+    private func addDoubtsWebViewController() {
         guard instituteSettings.isHelpdeskEnabled else { return }
 
         let doubtsWebViewController = self.getDoubtsWebViewController()

--- a/ios-app/UI/MainMenuTabViewController.swift
+++ b/ios-app/UI/MainMenuTabViewController.swift
@@ -68,9 +68,7 @@ class MainMenuTabViewController: UITabBarController {
             viewControllers?.remove(at: 1)
         }
         
-        if (instituteSettings.isHelpdeskEnabled) {
-            viewControllers?.append(self.getDoubtsWebViewController())
-        }
+        addDoubtsWebViewController(to: &viewControllers)
         
         if (UserDefaults.standard.string(forKey: Constants.REGISTER_DEVICE_TOKEN) == "true") {
             let deviceToken = UserDefaults.standard.string(forKey: Constants.DEVICE_TOKEN)
@@ -109,6 +107,17 @@ class MainMenuTabViewController: UITabBarController {
         }
         
         SFMCSdk.initializeSdk(ConfigBuilder().setPush(config: mobilePushConfiguration, onCompletion: completionHandler).build())
+    }
+    
+    private func addDoubtsWebViewController(to viewControllers: inout [UIViewController]?) {
+        guard instituteSettings.isHelpdeskEnabled else { return }
+
+        let doubtsWebViewController = self.getDoubtsWebViewController()
+        if (viewControllers?.count ?? 0) > 3 {
+            viewControllers?.insert(doubtsWebViewController, at: 2)
+        } else {
+            viewControllers?.append(doubtsWebViewController)
+        }
     }
     
     func getDoubtsWebViewController() -> WebViewController {


### PR DESCRIPTION
- This PR addresses an issue in MainMenuTabViewController where the Doubts screen was always appended to the view controllers list. The new behavior ensures the Doubts screen is added at index 3 if there are more than three view controllers; otherwise, it will be appended to the list.
- Previously, the Doubts WebViewController was always appended, leading to inconsistencies in its position. This fix ensures a consistent placement at index 3, aligning with the design expectations.