### PR TITLE
fix: Implement observer for InstituteSettings to prevent crashes

### DIFF
--- a/CourseKit/Source/Database/DBManager.swift
+++ b/CourseKit/Source/Database/DBManager.swift
@@ -154,18 +154,4 @@ public class DBManager<T: Object> {
             print("Error during Realm write transaction: \(error)")
         }
     }
-    
-    public func observeAllItems(
-        completion: @escaping (Results<T>) -> Void
-    ) -> NotificationToken? {
-        let results = getResultsFromDB()
-        return results.observe { changes in
-            switch changes {
-            case .initial(let settings), .update(let settings, _, _, _):
-                completion(settings)
-            case .error(let error):
-                print("Error observing Realm objects: \(error)")
-            }
-        }
-    }
 }

--- a/CourseKit/Source/Database/DBManager.swift
+++ b/CourseKit/Source/Database/DBManager.swift
@@ -154,4 +154,18 @@ public class DBManager<T: Object> {
             print("Error during Realm write transaction: \(error)")
         }
     }
+    
+    public func observeAllItems(
+        completion: @escaping (Results<T>) -> Void
+    ) -> NotificationToken? {
+        let results = getResultsFromDB()
+        return results.observe { changes in
+            switch changes {
+            case .initial(let settings), .update(let settings, _, _, _):
+                completion(settings)
+            case .error(let error):
+                print("Error observing Realm objects: \(error)")
+            }
+        }
+    }
 }

--- a/CourseKit/Source/Repostories/InstituteRepository.swift
+++ b/CourseKit/Source/Repostories/InstituteRepository.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import RealmSwift
 
 public class InstituteRepository {
 
@@ -51,5 +52,20 @@ public class InstituteRepository {
 
     private func clearCache() {
         DBManager<InstituteSettings>().deleteAllFromDatabase()
+    }
+    
+    public func observeSettingsChanges(
+        completion: @escaping (InstituteSettings?) -> Void
+    ) -> NotificationToken? {
+        return DBManager<InstituteSettings>().getResultsFromDB().observe { changes in
+            switch changes {
+            case .initial(let settings), .update(let settings, _, _, _):
+                if settings.isNotEmpty {
+                    completion(settings.first)
+                }
+            case .error(let error):
+                print("Error observing Realm objects: \(error)")
+            }
+        }
     }
 }

--- a/ios-app/UI/LoginViewController.swift
+++ b/ios-app/UI/LoginViewController.swift
@@ -77,19 +77,18 @@ class LoginViewController: BaseTextFieldViewController {
     }
     
     func observeInstituteSettings() {
-        instituteSettingsToken = DBManager<InstituteSettings>().observeAllItems { [weak self] settings in
-            self?.updateUI(settings: settings)
+        instituteSettingsToken = InstituteRepository.shared.observeSettingsChanges { [weak self] newSettings in
+            guard let self = self else { return }
+            self.updateUI(settings: newSettings)
         }
     }
 
-    func updateUI(settings : Results<InstituteSettings>?) {
+    func updateUI(settings : InstituteSettings?) {
         guard let settings = settings else { return }
-        if(settings.isNotEmpty) {
-            self.instituteSettings = settings[0]
-            signUpLayout.isHidden = !instituteSettings.allowSignup
-            socialLoginLayout.isHidden = !instituteSettings.facebookLoginEnabled
-            forgotPasswordButton.isHidden = instituteSettings.disableForgotPassword
-        }
+        self.instituteSettings = settings
+        signUpLayout.isHidden = !instituteSettings.allowSignup
+        socialLoginLayout.isHidden = !instituteSettings.facebookLoginEnabled
+        forgotPasswordButton.isHidden = instituteSettings.disableForgotPassword
     }
 
     deinit {

--- a/ios-app/UI/LoginViewController.swift
+++ b/ios-app/UI/LoginViewController.swift
@@ -77,17 +77,8 @@ class LoginViewController: BaseTextFieldViewController {
     }
     
     func observeInstituteSettings() {
-        var settings : Results<InstituteSettings>? = DBManager<InstituteSettings>().getResultsFromDB()
-        instituteSettingsToken = settings?.observe { [weak self] changes in
-        guard let self = self else { return }
-        switch changes {
-            case .initial(let settings):
-                self.updateUI(settings: settings)
-            case .update(let settings, _, _, _):
-                self.updateUI(settings: settings)
-            case .error(let error):
-                print("Error observing Realm objects: \(error)")
-            }
+        instituteSettingsToken = DBManager<InstituteSettings>().observeAllItems { [weak self] settings in
+            self?.updateUI(settings: settings)
         }
     }
 


### PR DESCRIPTION
- Previously, the `InstituteSettings` object was being refreshed in the background, causing crashes when accessing a deleted object. This update introduces an observer for `InstituteSettings`, ensuring that UI updates reflect the latest changes while preventing access to outdated objects. The observer updates the UI dynamically and properly handles object lifecycle changes.