### PR TITLE
fix: Add Privacy Usage Description for Location.

### DIFF
--- a/ios-app/Info.plist
+++ b/ios-app/Info.plist
@@ -59,6 +59,12 @@
 	<string>To take image &amp; upload in comments/forum</string>
 	<key>NSContactsUsageDescription</key>
 	<string>This app requires access to your contacts to allow you to invite others to meetings.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Your location information will for notifications</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>Your location information will for notifications</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Your location information will for notifications</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>For people to hear you during meetings, we need access to your microphone.</string>
 	<key>NSPhotoLibraryUsageDescription</key>


### PR DESCRIPTION
- In this commit, we are adding Privacy Usage Descriptions for `Location`.
- The MarketingCloudSDK uses these privacy options, and although our app doesn't utilize these features, The App Store Connect policy requires us to provide purpose strings explaining the use of these privacy options.