### PR TITLE
fix: Show login activity screen on parallel login error

### DIFF
--- a/ios-app/Utils/AuthErrorHandler.swift
+++ b/ios-app/Utils/AuthErrorHandler.swift
@@ -56,10 +56,10 @@ class AuthErrorHandler: AuthErrorHandlingDelegate {
                 topController = presentedViewController
             }
             let storyboard = UIStoryboard(name: Constants.MAIN_STORYBOARD, bundle: nil)
-            let loginViewController = storyboard.instantiateViewController(withIdentifier:
-                                        Constants.LOGIN_VIEW_CONTROLLER) as! LoginViewController
+            let loginActivityViewController = storyboard.instantiateViewController(withIdentifier:
+                                        Constants.LOGIN_ACTIVITY_VIEW_CONTROLLER) as! LoginActivityViewController
             
-            topController.present(loginViewController, animated: true, completion: nil)
+            topController.present(loginActivityViewController, animated: true, completion: nil)
         }
     }
     


### PR DESCRIPTION
- Previously, when a user encountered a parallel login error, they were redirected to the login screen without an option to log out. This update ensures that the login activity screen is shown instead, allowing users to log out properly before re-authenticating.