### PR TITLE
fix: Show success message on parallel logout in LoginActivity

### DIFF
--- a/ios-app/UI/LoginActivityViewController.swift
+++ b/ios-app/UI/LoginActivityViewController.swift
@@ -199,10 +199,12 @@ class LoginActivityViewController: UIViewController, UITableViewDelegate, UITabl
 
             if let error = error {
                 self.activityIndicator?.stopAnimating()
-                debugPrint(error.message ?? "No error")
-                debugPrint(error.kind)
-                let (_, _, description) = error.getDisplayInfo()
-                TTGSnackbar(message: description, duration: .middle).show()
+                if (error.statusCode == 200){
+                    TTGSnackbar(message: "Successfully logged out of all other devices.", duration: .middle).show()
+                } else {
+                    let (_, _, description) = error.getDisplayInfo()
+                    TTGSnackbar(message: description, duration: .middle).show()
+                }
                 return
             }
 


### PR DESCRIPTION
- The logout devices API returns an empty response, but our iOS TPApiClient handling mechanism treats an empty response as an error. Since this behavior is defined in the base class and cannot be changed, we handle it in the subclass (LoginActivityViewController). Now, upon receiving the response, we check the status code—if it is 200, we display a success message; otherwise, we show the error message from the API.