### PR TITLE
feat: Implement native PDF download and preview

### DIFF
--- a/CourseKit/Source/UI/ViewControllers/PreviewPDFViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/PreviewPDFViewController.swift
@@ -1,0 +1,163 @@
+//
+//  PreviewPDFViewController.swift
+//  ios-app
+//
+//  Created by Pruthivi Raj on 10/06/25.
+//  Copyright © 2025 Testpress. All rights reserved.
+//
+
+import Foundation
+import WebKit
+import UIKit
+
+class PreviewPDFViewController: WebViewController, WKScriptMessageHandler, UIDocumentInteractionControllerDelegate {
+
+    private var documentInteractionController: UIDocumentInteractionController?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.setStatusBarColor()
+    }
+
+    override func initWebView() {
+        let contentController = WKUserContentController()
+        contentController.add(self, name: "openPdf")
+        let config = WKWebViewConfiguration()
+        config.userContentController = contentController
+        config.preferences.javaScriptEnabled = true
+        webView = WKWebView(frame: parentView.bounds, configuration: config)
+        webView.customUserAgent = "TestpressiOSApp/WebView"
+    }
+
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        if message.name == "openPdf" {
+            if let body = message.body as? [String: Any] {
+                guard let pdfUrlString = body["url"] as? String,
+                      let authKey = body["key"] as? String,
+                      let url = URL(string: pdfUrlString) else {
+                    showErrorDialog(message: "Missing URL or Auth Key for PDF.")
+                    return
+                }
+                let pdfName = (body["name"] as? String) ?? "response.pdf"
+                handleDownloadFile(url: pdfUrlString, authKey: authKey, fileName: pdfName)
+            } else {
+                showErrorDialog(message: "Invalid data received from web view.")
+            }
+        }
+    }
+    
+    
+    func handleDownloadFile(url: String, authKey: String, fileName: String) {
+        guard let fileUrl = URL(string: url) else {
+            print("Invalid URL.")
+            return
+        }
+        
+        var request = URLRequest(url: fileUrl)
+        request.addValue(authKey, forHTTPHeaderField: "Authorization")
+
+        FileDownloadUtility.shared.downloadFile(viewController: self, from: request, fileName: fileName) { (destinationURL, error) in
+            if let destinationURL = destinationURL {
+                debugPrint(destinationURL)
+            } else if let error = error {
+                self.presentErrorDialog(error: error)
+            }
+        }
+    }
+    
+    private func presentErrorDialog(error: Error) {
+            let errorAlert = UIAlertController(title: "Error", message: error.localizedDescription, preferredStyle: .alert)
+            errorAlert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+            self.present(errorAlert, animated: true, completion: nil)
+        }
+
+    private func downloadAndOpenPdf(url: URL, authKey: String, pdfName: String) {
+        showLoadingDialog()
+
+        var request = URLRequest(url: url)
+        request.addValue(authKey, forHTTPHeaderField: "Authorization")
+
+        let task = URLSession.shared.downloadTask(with: request) { [weak self] tempLocalUrl, response, error in
+            DispatchQueue.main.async {
+                self?.activityIndicator?.stopAnimating()
+                self?.activityIndicator?.removeFromSuperview()
+            }
+
+            if let error = error {
+                DispatchQueue.main.async {
+                    self?.showErrorDialog(message: "Failed to download PDF: \(error.localizedDescription)")
+                }
+                return
+            }
+
+            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+                DispatchQueue.main.async {
+                    let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+                    self?.showErrorDialog(message: "Download failed with HTTP status code: \(statusCode)")
+                }
+                return
+            }
+
+            guard let tempLocalUrl = tempLocalUrl else {
+                DispatchQueue.main.async {
+                    self?.showErrorDialog(message: "PDF content was empty.")
+                }
+                return
+            }
+
+            do {
+                let documentsURL = FileManager.default.temporaryDirectory
+                let destinationURL = documentsURL.appendingPathComponent(pdfName)
+
+                // If file already exists, remove it
+                if FileManager.default.fileExists(atPath: destinationURL.path) {
+                    try FileManager.default.removeItem(at: destinationURL)
+                }
+
+                try FileManager.default.moveItem(at: tempLocalUrl, to: destinationURL)
+
+                DispatchQueue.main.async {
+                    self?.openPdfFile(fileURL: destinationURL)
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    self?.showErrorDialog(message: "Failed to save PDF: \(error.localizedDescription)")
+                }
+            }
+        }
+        task.resume()
+    }
+
+    private func openPdfFile(fileURL: URL) {
+        documentInteractionController = UIDocumentInteractionController(url: fileURL)
+        documentInteractionController?.delegate = self
+        // Present options to open the PDF
+        if !(documentInteractionController?.presentOptionsMenu(from: view.bounds, in: view, animated: true) ?? false) {
+            showErrorDialog(message: "No app found to open PDF.")
+        }
+    }
+
+    private func showLoadingDialog() {
+        activityIndicator = UIActivityIndicatorView(style: .large)
+        activityIndicator?.center = view.center
+        activityIndicator?.hidesWhenStopped = true
+        view.addSubview(activityIndicator!)
+        activityIndicator?.startAnimating()
+    }
+
+    private func showErrorDialog(message: String) {
+        let alert = UIAlertController(title: "Error", message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+        present(alert, animated: true, completion: nil)
+    }
+
+    override func onFinishLoadingWebView() {
+        activityIndicator?.stopAnimating()
+        activityIndicator?.removeFromSuperview()
+    }
+
+    override func goBack() {
+        self.cleanAllCookies()
+        self.dismiss(animated: true, completion: nil)
+    }
+}

--- a/CourseKit/Source/UI/ViewControllers/PreviewPDFViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/PreviewPDFViewController.swift
@@ -66,83 +66,9 @@ class PreviewPDFViewController: WebViewController, WKScriptMessageHandler, UIDoc
     }
     
     private func presentErrorDialog(error: Error) {
-            let errorAlert = UIAlertController(title: "Error", message: error.localizedDescription, preferredStyle: .alert)
-            errorAlert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-            self.present(errorAlert, animated: true, completion: nil)
-        }
-
-    private func downloadAndOpenPdf(url: URL, authKey: String, pdfName: String) {
-        showLoadingDialog()
-
-        var request = URLRequest(url: url)
-        request.addValue(authKey, forHTTPHeaderField: "Authorization")
-
-        let task = URLSession.shared.downloadTask(with: request) { [weak self] tempLocalUrl, response, error in
-            DispatchQueue.main.async {
-                self?.activityIndicator?.stopAnimating()
-                self?.activityIndicator?.removeFromSuperview()
-            }
-
-            if let error = error {
-                DispatchQueue.main.async {
-                    self?.showErrorDialog(message: "Failed to download PDF: \(error.localizedDescription)")
-                }
-                return
-            }
-
-            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
-                DispatchQueue.main.async {
-                    let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
-                    self?.showErrorDialog(message: "Download failed with HTTP status code: \(statusCode)")
-                }
-                return
-            }
-
-            guard let tempLocalUrl = tempLocalUrl else {
-                DispatchQueue.main.async {
-                    self?.showErrorDialog(message: "PDF content was empty.")
-                }
-                return
-            }
-
-            do {
-                let documentsURL = FileManager.default.temporaryDirectory
-                let destinationURL = documentsURL.appendingPathComponent(pdfName)
-
-                // If file already exists, remove it
-                if FileManager.default.fileExists(atPath: destinationURL.path) {
-                    try FileManager.default.removeItem(at: destinationURL)
-                }
-
-                try FileManager.default.moveItem(at: tempLocalUrl, to: destinationURL)
-
-                DispatchQueue.main.async {
-                    self?.openPdfFile(fileURL: destinationURL)
-                }
-            } catch {
-                DispatchQueue.main.async {
-                    self?.showErrorDialog(message: "Failed to save PDF: \(error.localizedDescription)")
-                }
-            }
-        }
-        task.resume()
-    }
-
-    private func openPdfFile(fileURL: URL) {
-        documentInteractionController = UIDocumentInteractionController(url: fileURL)
-        documentInteractionController?.delegate = self
-        // Present options to open the PDF
-        if !(documentInteractionController?.presentOptionsMenu(from: view.bounds, in: view, animated: true) ?? false) {
-            showErrorDialog(message: "No app found to open PDF.")
-        }
-    }
-
-    private func showLoadingDialog() {
-        activityIndicator = UIActivityIndicatorView(style: .large)
-        activityIndicator?.center = view.center
-        activityIndicator?.hidesWhenStopped = true
-        view.addSubview(activityIndicator!)
-        activityIndicator?.startAnimating()
+        let errorAlert = UIAlertController(title: "Error", message: error.localizedDescription, preferredStyle: .alert)
+        errorAlert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+        self.present(errorAlert, animated: true, completion: nil)
     }
 
     private func showErrorDialog(message: String) {
@@ -159,5 +85,9 @@ class PreviewPDFViewController: WebViewController, WKScriptMessageHandler, UIDoc
     override func goBack() {
         self.cleanAllCookies()
         self.dismiss(animated: true, completion: nil)
+    }
+    
+    deinit {
+        (webView.configuration.userContentController).removeScriptMessageHandler(forName: "openPdf")
     }
 }

--- a/CourseKit/Source/UI/ViewControllers/ReviewQuestionsViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/ReviewQuestionsViewController.swift
@@ -492,9 +492,10 @@ class ReviewQuestionsViewController: BaseQuestionsViewController, WKScriptMessag
     }
     
     func handlePreviewFile(url: String) {
-        let webViewController = WebViewController()
+        let webViewController = PreviewPDFViewController()
         webViewController.title = "PDF Preview"
         webViewController.url = url
+        webViewController.modalPresentationStyle = .fullScreen
         present(webViewController, animated: true, completion: nil)
     }
     

--- a/CourseKit/Source/Utils/FileDownloadUtility.swift
+++ b/CourseKit/Source/Utils/FileDownloadUtility.swift
@@ -133,6 +133,7 @@ public class FileDownloadUtility: NSObject, URLSessionDelegate, URLSessionDownlo
     private func handleDownloadCompletion(_ url: URL?, _ error: Error?, completion: ((URL?, Error?) -> Void)?) {
         DispatchQueue.main.async {
             self.dismissProgressDialog(){
+                self.fileName = nil    
                 if let url = url {
                     self.presentActivityViewController(with: url)
                 }

--- a/CourseKit/Source/Utils/FileDownloadUtility.swift
+++ b/CourseKit/Source/Utils/FileDownloadUtility.swift
@@ -10,6 +10,7 @@ public class FileDownloadUtility: NSObject, URLSessionDelegate, URLSessionDownlo
     private var downloadCompletionHandler: ((URL?, Error?) -> Void)?
     private var alertController: UIAlertController?
     private weak var presentingViewController: UIViewController?
+    private var fileName: String?
     
     private override init() {
         super.init()
@@ -18,17 +19,33 @@ public class FileDownloadUtility: NSObject, URLSessionDelegate, URLSessionDownlo
         alertController = UIUtils.initProgressDialog(message: "Downloading..." + "\n\n")
     }
     
-    public func downloadFile(viewController: UIViewController, from url: URL, completion: @escaping (URL?, Error?) -> Void) {
+    public func downloadFile(
+        viewController: UIViewController,
+        from url: URL,
+        fileName: String? = nil,
+        completion: @escaping (URL?, Error?) -> Void
+    ) {
+        let request = URLRequest(url: url)
+        downloadFile(viewController: viewController, from: request, fileName: fileName, completion: completion)
+    }
+
+    public func downloadFile(
+        viewController: UIViewController,
+        from urlRequest: URLRequest,
+        fileName: String? = nil,
+        completion: @escaping (URL?, Error?) -> Void
+    ) {
+        self.fileName = fileName
         presentingViewController = viewController
         presentingViewController?.present(alertController!, animated: true, completion: nil)
         
         downloadTask?.cancel()
-        startDownloadTask(from: url, completion: completion)
+        startDownloadTask(from: urlRequest, completion: completion)
     }
         
-    private func startDownloadTask(from url: URL, completion: @escaping (URL?, Error?) -> Void) {
+    private func startDownloadTask(from urlRequest: URLRequest, completion: @escaping (URL?, Error?) -> Void) {
         self.downloadCompletionHandler = completion
-        downloadTask = session.downloadTask(with: url)
+        downloadTask = session.downloadTask(with: urlRequest)
         downloadTask?.resume()
     }
     
@@ -50,7 +67,7 @@ public class FileDownloadUtility: NSObject, URLSessionDelegate, URLSessionDownlo
     }
     
     func generateUniqueDestinationPath(downloadedUrl: URL) -> URL {
-        let filename = downloadedUrl.lastPathComponent
+        let filename = fileName ?? downloadedUrl.lastPathComponent
         let downloadsPath = try! FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
         var uniqueFilename = filename
         var filePath = downloadsPath.appendingPathComponent(uniqueFilename)
@@ -69,8 +86,13 @@ public class FileDownloadUtility: NSObject, URLSessionDelegate, URLSessionDownlo
     
     func presentActivityViewController(with fileURL: URL) {
         let activityViewController = UIActivityViewController(activityItems: [fileURL], applicationActivities: nil)
-        activityViewController.popoverPresentationController?.sourceView = presentingViewController!.view
-        
+        activityViewController.popoverPresentationController?.sourceView = presentingViewController?.view
+        activityViewController.popoverPresentationController?.sourceRect = CGRect(
+            x: presentingViewController!.view.bounds.maxX,
+            y: presentingViewController!.view.bounds.minY,
+            width: 0, height: 0)
+        activityViewController.popoverPresentationController?.permittedArrowDirections = [.up, .right]
+
         presentingViewController!.present(activityViewController, animated: true, completion: nil)
     }
     

--- a/ios-app.xcodeproj/project.pbxproj
+++ b/ios-app.xcodeproj/project.pbxproj
@@ -394,6 +394,10 @@
 		8CDE264E239EB04900BA04C6 /* VideoPlayerControlsViewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CDE264D239EB04900BA04C6 /* VideoPlayerControlsViewTest.swift */; };
 		8CDE2650239EB61D00BA04C6 /* VideoPlayerViewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CDE264F239EB61D00BA04C6 /* VideoPlayerViewTest.swift */; };
 		8CDE2652239F26B700BA04C6 /* TestVideoContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CDE2651239F26B700BA04C6 /* TestVideoContentViewController.swift */; };
+		A4A1E4F72DF1648600C72932 /* MobileRTC.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D9D3721B2D3FB086002E9FE2 /* MobileRTC.xcframework */; };
+		A4A1E4FA2DF164C400C72932 /* MobileRTC.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D9D3721B2D3FB086002E9FE2 /* MobileRTC.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A4A1E4FC2DF1658700C72932 /* MobileRTCResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = A4A1E4FB2DF1658700C72932 /* MobileRTCResources.bundle */; };
+		A4B98DBA2DF85A9300471BA7 /* PreviewPDFViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B98DB92DF85A8C00471BA7 /* PreviewPDFViewController.swift */; };
 		D90F83672CDCD8220030C38F /* OfflineDownloadsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D90F83662CDCD8220030C38F /* OfflineDownloadsViewController.swift */; };
 		D932B2B32CCBB357002B6D30 /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = D932B2B22CCBB357002B6D30 /* Realm */; };
 		D932B2B52CCBB357002B6D30 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = D932B2B42CCBB357002B6D30 /* RealmSwift */; };
@@ -403,9 +407,6 @@
 		D953EB6F2CDDE90B00B62759 /* OfflineDownloadsTabController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D953EB6E2CDDE90B00B62759 /* OfflineDownloadsTabController.swift */; };
 		D9A2F2AC2CE1DFBF0052802D /* OfflineDownloadTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A2F2AB2CE1DFBF0052802D /* OfflineDownloadTableViewCell.swift */; };
 		D9CCCA5C2CF5DBA700B60B0F /* MarketingCloudSDK in Frameworks */ = {isa = PBXBuildFile; productRef = D9CCCA5B2CF5DBA700B60B0F /* MarketingCloudSDK */; };
-		D9D3721C2D3FB087002E9FE2 /* MobileRTC.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D9D3721B2D3FB086002E9FE2 /* MobileRTC.xcframework */; };
-		D9D3721D2D3FB087002E9FE2 /* MobileRTC.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D9D3721B2D3FB086002E9FE2 /* MobileRTC.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D9D3721F2D3FB0A2002E9FE2 /* MobileRTCResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = D9D3721E2D3FB0A1002E9FE2 /* MobileRTCResources.bundle */; };
 		D9EDF1F12A0CF10800A6CB2E /* FBAEMKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 259932702A0A3F6800866CA8 /* FBAEMKit.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D9EDF1F22A0CF10800A6CB2E /* FBSDKCoreKit_Basics.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2599326E2A0A3F4600866CA8 /* FBSDKCoreKit_Basics.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D9EDF1F32A0CF10800A6CB2E /* FBSDKLoginKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2599326C2A0A3C2A00866CA8 /* FBSDKLoginKit.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -467,10 +468,10 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				A4A1E4FA2DF164C400C72932 /* MobileRTC.xcframework in Embed Frameworks */,
 				841380232C9D9CCE004D5846 /* CourseKit.framework in Embed Frameworks */,
 				D9EDF1F12A0CF10800A6CB2E /* FBAEMKit.xcframework in Embed Frameworks */,
 				D9EDF1F22A0CF10800A6CB2E /* FBSDKCoreKit_Basics.xcframework in Embed Frameworks */,
-				D9D3721D2D3FB087002E9FE2 /* MobileRTC.xcframework in Embed Frameworks */,
 				D9EDF1F32A0CF10800A6CB2E /* FBSDKLoginKit.xcframework in Embed Frameworks */,
 				D9EDF1F42A0CF10800A6CB2E /* FBSDKCoreKit.xcframework in Embed Frameworks */,
 			);
@@ -842,6 +843,9 @@
 		8CDE2651239F26B700BA04C6 /* TestVideoContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestVideoContentViewController.swift; sourceTree = "<group>"; };
 		8CF6972C232652A80040A986 /* Stackview+BackgroundColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Stackview+BackgroundColor.swift"; sourceTree = "<group>"; };
 		9B482AA21F7CADEABC2BF009 /* ios_appTests-ios_appMocks.generated.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = "ios_appTests-ios_appMocks.generated.swift"; path = "MockingbirdMocks/ios_appTests-ios_appMocks.generated.swift"; sourceTree = "<group>"; };
+		A4A1E4FB2DF1658700C72932 /* MobileRTCResources.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = MobileRTCResources.bundle; path = Carthage/Build/MobileRTCResources.bundle; sourceTree = "<group>"; };
+		A4B98DB92DF85A8C00471BA7 /* PreviewPDFViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewPDFViewController.swift; sourceTree = "<group>"; };
+		A4EFEE242DF9B11D00CC0413 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		D907E7A82B19D11C00BEA874 /* Language.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Language.swift; path = CourseKit/Source/Database/Models/Language.swift; sourceTree = SOURCE_ROOT; };
 		D90F83662CDCD8220030C38F /* OfflineDownloadsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineDownloadsViewController.swift; sourceTree = "<group>"; };
 		D9151E7E2A7B8A9C00EAE2DF /* CustomTestGenerationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTestGenerationViewController.swift; sourceTree = "<group>"; };
@@ -854,7 +858,6 @@
 		D990C7F12B31765E00B3ED4D /* DirectionTranslation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectionTranslation.swift; sourceTree = "<group>"; };
 		D9A2F2AB2CE1DFBF0052802D /* OfflineDownloadTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineDownloadTableViewCell.swift; sourceTree = "<group>"; };
 		D9D3721B2D3FB086002E9FE2 /* MobileRTC.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:BJ4HAAB9B3:Zoom Video Communications, Inc."; lastKnownFileType = wrapper.xcframework; name = MobileRTC.xcframework; path = Carthage/Build/MobileRTC.xcframework; sourceTree = "<group>"; };
-		D9D3721E2D3FB0A1002E9FE2 /* MobileRTCResources.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = MobileRTCResources.bundle; path = Carthage/Build/MobileRTCResources.bundle; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -869,6 +872,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A4A1E4F72DF1648600C72932 /* MobileRTC.xcframework in Frameworks */,
 				0386961C2BF7602600E36F8F /* Alamofire in Frameworks */,
 				03A60FAB2CB4153900079A7C /* Sentry in Frameworks */,
 				259932712A0A3F6800866CA8 /* FBAEMKit.xcframework in Frameworks */,
@@ -877,7 +881,6 @@
 				2570A24921CA0D770097C6FE /* FirebaseInstanceID.framework in Frameworks */,
 				2570A24A21CA0D770097C6FE /* FirebaseCore.framework in Frameworks */,
 				2570A24B21CA0D770097C6FE /* GoogleUtilities.framework in Frameworks */,
-				D9D3721C2D3FB087002E9FE2 /* MobileRTC.xcframework in Frameworks */,
 				036CE86F2CA6F79600183BA8 /* IGListDiffKit in Frameworks */,
 				2570A24F21CA0D770097C6FE /* Firebase.framework in Frameworks */,
 				03494F4B2CBEAFA700C6A44B /* TOCropViewController in Frameworks */,
@@ -1318,7 +1321,7 @@
 		2F26ADD91E8249D70031E6F4 = {
 			isa = PBXGroup;
 			children = (
-				D9D3721E2D3FB0A1002E9FE2 /* MobileRTCResources.bundle */,
+				A4A1E4FB2DF1658700C72932 /* MobileRTCResources.bundle */,
 				038696232BF7692900E36F8F /* PrivacyInfo.xcprivacy */,
 				2F26ADE41E8249D70031E6F4 /* ios-app */,
 				2F26ADF91E8249D70031E6F4 /* ios-appTests */,
@@ -1503,6 +1506,7 @@
 		8413800E2C9D9CCD004D5846 /* CourseKit */ = {
 			isa = PBXGroup;
 			children = (
+				A4EFEE242DF9B11D00CC0413 /* Info.plist */,
 				8413802E2C9DA075004D5846 /* Source */,
 				8413800F2C9D9CCD004D5846 /* CourseKit.h */,
 				841380102C9D9CCD004D5846 /* CourseKit.docc */,
@@ -1521,6 +1525,7 @@
 		8413802D2C9DA066004D5846 /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
+				A4B98DB92DF85A8C00471BA7 /* PreviewPDFViewController.swift */,
 				8C3D6432239D5D8E001C7FE4 /* RelatedContentsCell.swift */,
 				2570501A246EA32600E6C688 /* LoadingViewController.swift */,
 				259E2FC82428991B0096B6D1 /* ShareToUnlockViewController.swift */,
@@ -1910,7 +1915,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D9D3721F2D3FB0A2002E9FE2 /* MobileRTCResources.bundle in Resources */,
+				A4A1E4FC2DF1658700C72932 /* MobileRTCResources.bundle in Resources */,
 				2503DF6B263C17DA003226AD /* PostCarouselViewCell.xib in Resources */,
 				2503DF70263FAC0A003226AD /* ChapterContentViewCell.xib in Resources */,
 				2570A23F21CA0D260097C6FE /* GoogleService-Info.plist in Resources */,
@@ -2017,7 +2022,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
+			shellScript = "/opt/homebrew/bin/carthage copy-frameworks\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -2296,6 +2301,7 @@
 				03E4AF592CAEDF7F00ECC34D /* VideoConference.swift in Sources */,
 				03E4AF572CAEDF7F00ECC34D /* InstituteSettings.swift in Sources */,
 				038CB2AD2CBD278600164127 /* BookmarksDetailDataSource.swift in Sources */,
+				A4B98DBA2DF85A9300471BA7 /* PreviewPDFViewController.swift in Sources */,
 				03A60F6F2CB3F22800079A7C /* TPApiClient.swift in Sources */,
 				03E4AFAD2CAFCF6F00ECC34D /* Comment.swift in Sources */,
 				03A60F982CB3F3AD00079A7C /* Strings.swift in Sources */,
@@ -2721,6 +2727,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = CourseKit/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2024 Testpress. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -2773,6 +2780,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = CourseKit/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2024 Testpress. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;


### PR DESCRIPTION
- Previously, clicking a download button in a webview directly initiated a PDF download, lacking a native saving experience. This change introduces a JavaScript interface to communicate with iOS, enabling the app to handle PDF downloads.

- The app now uses `PreviewPDFViewController` to intercept PDF download requests from webviews. It retrieves the PDF URL and an authentication key via JavaScript message handlers. `FileDownloadUtility` has been enhanced to accept `URLRequest` with custom headers for authenticated downloads and allows specifying a filename. Upon successful download, the app presents a native saving option to the user. This provides a more secure and user-friendly experience for handling PDF files accessed through webviews.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced PDF preview functionality, allowing users to securely view and open PDF files within the app and in external apps.
- **Enhancements**
  - Improved file download experience with support for custom filenames and enhanced sharing options, especially on iPad.
- **Bug Fixes**
  - Better error handling and user feedback during PDF downloads and previews.
- **Chores**
  - Updated project configuration to include new files and adjust framework integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->