### PR TITLE
fix: register Rubik font before usage to prevent crash

### DIFF
--- a/CourseKit/Source/TestpressCourse.swift
+++ b/CourseKit/Source/TestpressCourse.swift
@@ -41,6 +41,7 @@ public class TestpressCourse {
             let token: String = KeychainTokenItem.getToken()
             TPStreamsSDK.initialize(for : Provider.testpress, withOrgCode: subdomain, usingAuthToken: token)
         }
+        FontRegistrar.registerRubikFonts()
     }
     
     public func initializeDB() {

--- a/CourseKit/Source/Utils/FontRegistrar.swift
+++ b/CourseKit/Source/Utils/FontRegistrar.swift
@@ -14,7 +14,7 @@ public class FontRegistrar {
     public static func registerFont(
         withName fontName: String,
         fileExtension: String = "ttf",
-        bundle: Bundle = Bundle.main
+        bundle: Bundle = Bundle(for: FontRegistrar.self)
     ) -> Bool {
         guard let fontURL = bundle.url(forResource: fontName, withExtension: fileExtension) else {
             print("FontRegistrar: Font file \(fontName).\(fileExtension) not found in bundle.")

--- a/CourseKit/Source/Utils/FontRegistrar.swift
+++ b/CourseKit/Source/Utils/FontRegistrar.swift
@@ -1,0 +1,48 @@
+//
+//  FontRegistrar.swift
+//  ios-app
+//
+//  Created by Pruthivi Raj on 13/06/25.
+//  Copyright © 2025 Testpress. All rights reserved.
+//
+
+import UIKit
+import CoreText
+
+public class FontRegistrar {
+    @discardableResult
+    public static func registerFont(
+        withName fontName: String,
+        fileExtension: String = "ttf",
+        bundle: Bundle = Bundle.main
+    ) -> Bool {
+        guard let fontURL = bundle.url(forResource: fontName, withExtension: fileExtension) else {
+            print("FontRegistrar: Font file \(fontName).\(fileExtension) not found in bundle.")
+            return false
+        }
+
+        guard let dataProvider = CGDataProvider(url: fontURL as CFURL),
+              let font = CGFont(dataProvider) else {
+            print("FontRegistrar: Failed to create CGFont for \(fontName).")
+            return false
+        }
+
+        var error: Unmanaged<CFError>?
+        let success = CTFontManagerRegisterGraphicsFont(font, &error)
+
+        if !success {
+            if let error = error?.takeUnretainedValue() {
+                print("FontRegistrar: Failed to register font: \(error.localizedDescription)")
+            }
+            return false
+        }
+
+        print("FontRegistrar: Registered font: \(font.fullName ?? fontName as CFString)")
+        return true
+    }
+
+    public static func registerRubikFonts(bundle: Bundle = Bundle(for: FontRegistrar.self)) {
+        _ = registerFont(withName: "Rubik-Regular", bundle: bundle)
+        _ = registerFont(withName: "Rubik-Medium", bundle: bundle)
+    }
+}

--- a/ios-app.xcodeproj/project.pbxproj
+++ b/ios-app.xcodeproj/project.pbxproj
@@ -397,6 +397,7 @@
 		A4A1E4F72DF1648600C72932 /* MobileRTC.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D9D3721B2D3FB086002E9FE2 /* MobileRTC.xcframework */; };
 		A4A1E4FA2DF164C400C72932 /* MobileRTC.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D9D3721B2D3FB086002E9FE2 /* MobileRTC.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A4A1E4FC2DF1658700C72932 /* MobileRTCResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = A4A1E4FB2DF1658700C72932 /* MobileRTCResources.bundle */; };
+		A4B6EE6A2DFC221E006D6FD1 /* FontRegistrar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B6EE692DFC221C006D6FD1 /* FontRegistrar.swift */; };
 		A4B98DBA2DF85A9300471BA7 /* PreviewPDFViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B98DB92DF85A8C00471BA7 /* PreviewPDFViewController.swift */; };
 		D90F83672CDCD8220030C38F /* OfflineDownloadsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D90F83662CDCD8220030C38F /* OfflineDownloadsViewController.swift */; };
 		D932B2B32CCBB357002B6D30 /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = D932B2B22CCBB357002B6D30 /* Realm */; };
@@ -844,6 +845,7 @@
 		8CF6972C232652A80040A986 /* Stackview+BackgroundColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Stackview+BackgroundColor.swift"; sourceTree = "<group>"; };
 		9B482AA21F7CADEABC2BF009 /* ios_appTests-ios_appMocks.generated.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = "ios_appTests-ios_appMocks.generated.swift"; path = "MockingbirdMocks/ios_appTests-ios_appMocks.generated.swift"; sourceTree = "<group>"; };
 		A4A1E4FB2DF1658700C72932 /* MobileRTCResources.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = MobileRTCResources.bundle; path = Carthage/Build/MobileRTCResources.bundle; sourceTree = "<group>"; };
+		A4B6EE692DFC221C006D6FD1 /* FontRegistrar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontRegistrar.swift; sourceTree = "<group>"; };
 		A4B98DB92DF85A8C00471BA7 /* PreviewPDFViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewPDFViewController.swift; sourceTree = "<group>"; };
 		A4EFEE242DF9B11D00CC0413 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		D907E7A82B19D11C00BEA874 /* Language.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Language.swift; path = CourseKit/Source/Database/Models/Language.swift; sourceTree = SOURCE_ROOT; };
@@ -1220,6 +1222,7 @@
 		03E4AFD32CAFE62200ECC34D /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				A4B6EE692DFC221C006D6FD1 /* FontRegistrar.swift */,
 				0311ABC72D1EA32F00F7AA30 /* Toast.swift */,
 				2FC0F2DA1F863AAF0092BFDC /* Colors.swift */,
 				2FC0F2DB1F863AAF0092BFDC /* Images.swift */,
@@ -2185,6 +2188,7 @@
 				038CB2A82CBD278600164127 /* ContentDetailDataSource.swift in Sources */,
 				03CD0C7C2CB7D25200E17218 /* FileDownloadUtility.swift in Sources */,
 				03E4AFB92CAFCF6F00ECC34D /* SectionInfo.swift in Sources */,
+				A4B6EE6A2DFC221E006D6FD1 /* FontRegistrar.swift in Sources */,
 				038CB2972CBD278600164127 /* AttachmentDetailViewController.swift in Sources */,
 				038CB28B2CBD278600164127 /* QuestionsControllerSource.swift in Sources */,
 				038CB2AF2CBD278600164127 /* BookmarkFolderTableViewCell.swift in Sources */,


### PR DESCRIPTION
- The crash occurs because the custom Rubik font was not registered before use in the SDK, resulting in UIFont returning nil.
- To resolve this, a FontRegistrar utility class was added to register the required Rubik fonts from the SDK bundle at initialization. The font registration is now triggered in TestpressCourse.initialize() ensuring fonts are available before usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for dynamic registration of custom Rubik fonts within the app, enhancing font availability and consistency across the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->