### PR TITLE
fix: Replace deprecated openURL method

### DIFF
--- a/CourseKit/Source/UI/ViewControllers/AttachmentDetailViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/AttachmentDetailViewController.swift
@@ -237,7 +237,7 @@ class AttachmentDetailViewController: BaseUIViewController, URLSessionDownloadDe
     
     @IBAction func downloadAttachment(_ sender: UIButton) {
         var attachmentUrl = URL(string: content.attachment!.attachmentUrl)!
-        UIApplication.shared.openURL(attachmentUrl)
+        UIApplication.shared.open(attachmentUrl)
         viewModel?.createContentAttempt()
     }
     


### PR DESCRIPTION
- Replaced `UIApplication.shared.openURL` with `UIApplication.shared.open` to address deprecation in iOS 10. This change ensures compatibility with modern iOS versions and avoids warnings or potential issues during runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the method for opening attachment links to use a more modern and supported approach, ensuring continued compatibility with the latest system versions. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->