### PR TITLE
fix: Update camera permission message for clarity and user context

### DIFF
--- a/ios-app/Info.plist
+++ b/ios-app/Info.plist
@@ -56,7 +56,7 @@
 	<key>NSCalendarsUsageDescription</key>
 	<string>This app requires access to your calendar to schedule and manage meetings.</string>
 	<key>NSCameraUsageDescription</key>
-	<string>To take image &amp; upload in comments/forum</string>
+	<string>Allow camera access to take photos when asking doubts, posting in discussions, and updating your profile picture. Access will be requested the first time you use any of these features.</string>
 	<key>NSContactsUsageDescription</key>
 	<string>This app requires access to your contacts to allow you to invite others to meetings.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>


### PR DESCRIPTION
- The previous camera permission message was brief and lacked context, which could confuse users about when and why camera access is needed.
- This was caused by a vague string that didn’t explain the specific use cases for camera access.
- It is now reworded to clearly state that camera access is required for taking photos when asking doubts, posting in discussions, or updating the profile picture. It also clarifies that access will be requested only when the user first attempts these actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the camera access explanation in the app to provide a clearer and more detailed description for users when requesting permission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->