### PR TITLE
fix: Synchronize local exam attempt state with latest server state

### DIFF
--- a/CourseKit/Source/Repostories/AttemptRepository.swift
+++ b/CourseKit/Source/Repostories/AttemptRepository.swift
@@ -137,12 +137,12 @@ public class AttemptRepository {
         }
 
         if content != nil {
-            fetchContentRunningAttempt(attemptsUrl: url) { ca, error in
-                completion(ca, ca?.assessment, error)
+            fetchContentRunningAttempt(attemptsUrl: url) { contentAttempt, error in
+                completion(contentAttempt, contentAttempt?.assessment, error)
             }
         } else {
-            fetchRunningAttempt(attemptsUrl: url) { a, error in
-                completion(nil, a, error)
+            fetchRunningAttempt(attemptsUrl: url) { attempt, error in
+                completion(nil, attempt, error)
             }
         }
     }

--- a/CourseKit/Source/Repostories/AttemptRepository.swift
+++ b/CourseKit/Source/Repostories/AttemptRepository.swift
@@ -107,14 +107,14 @@ public class AttemptRepository {
         })
     }
 
-    private func fetchAttempt<T: TestpressModel>(attemptsUrl: String, type: T.Type, filter: @escaping (T) -> Bool, completion: @escaping (T?, TPError?) -> Void) {
-        TPApiClient.getListItems(endpointProvider: TPEndpointProvider(.loadAttempts, url: attemptsUrl), completion: { (response: TPApiResponse<T>?, error: TPError?) in
+    private func fetchAttempt<T: TestpressModel>(attemptsUrl: String, type: T.Type, queryParams: [String: String] = [:], completion: @escaping (T?, TPError?) -> Void) {
+        TPApiClient.getListItems(endpointProvider: TPEndpointProvider(.loadAttempts, url: attemptsUrl, queryParams: queryParams), completion: { (response: TPApiResponse<T>?, error: TPError?) in
             if let error = error {
                 completion(nil, error)
                 return
             }
 
-            let attempt = response?.results.first(where: filter)
+            let attempt = response?.results.first
             completion(attempt, nil)
         }, type: T.self)
     }
@@ -127,11 +127,11 @@ public class AttemptRepository {
         }
 
         if content != nil {
-            fetchAttempt(attemptsUrl: url, type: ContentAttempt.self, filter: { $0.assessment?.state == Constants.STATE_RUNNING }) { contentAttempt, error in
+            fetchAttempt(attemptsUrl: url, type: ContentAttempt.self, queryParams: [Constants.STATE: "paused"]) { contentAttempt, error in
                 completion(contentAttempt, contentAttempt?.assessment, error)
             }
         } else {
-            fetchAttempt(attemptsUrl: url, type: Attempt.self, filter: { $0.state == Constants.STATE_RUNNING }) { attempt, error in
+            fetchAttempt(attemptsUrl: url, type: Attempt.self, queryParams: [Constants.STATE: "paused"]) { attempt, error in
                 completion(nil, attempt, error)
             }
         }

--- a/CourseKit/Source/Repostories/AttemptRepository.swift
+++ b/CourseKit/Source/Repostories/AttemptRepository.swift
@@ -107,18 +107,19 @@ public class AttemptRepository {
         })
     }
 
-    private func fetchLatestAttempt<T: TestpressModel>(attemptsUrl: String, type: T.Type, filter: @escaping (T) -> Bool, completion: @escaping (T?, TPError?) -> Void) {
+    private func fetchAttempt<T: TestpressModel>(attemptsUrl: String, type: T.Type, filter: @escaping (T) -> Bool, completion: @escaping (T?, TPError?) -> Void) {
         TPApiClient.getListItems(endpointProvider: TPEndpointProvider(.loadAttempts, url: attemptsUrl), completion: { (response: TPApiResponse<T>?, error: TPError?) in
             if let error = error {
                 completion(nil, error)
                 return
             }
-            let latestAttempt = response?.results.first(where: filter)
-            completion(latestAttempt, nil)
+
+            let attempt = response?.results.first(where: filter)
+            completion(attempt, nil)
         }, type: T.self)
     }
 
-    public func fetchLatestRunningAttempt(exam: Exam, content: Content?, completion: @escaping (ContentAttempt?, Attempt?, TPError?) -> Void) {
+    public func fetchRunningAttempt(exam: Exam, content: Content?, completion: @escaping (ContentAttempt?, Attempt?, TPError?) -> Void) {
         let url = content?.getAttemptsUrl() ?? exam.attemptsUrl
         guard !url.isEmpty else {
             completion(nil, nil, nil)
@@ -126,15 +127,13 @@ public class AttemptRepository {
         }
 
         if content != nil {
-            fetchLatestAttempt(attemptsUrl: url, type: ContentAttempt.self, filter: { $0.assessment?.state == Constants.STATE_RUNNING }) { contentAttempt, error in
+            fetchAttempt(attemptsUrl: url, type: ContentAttempt.self, filter: { $0.assessment?.state == Constants.STATE_RUNNING }) { contentAttempt, error in
                 completion(contentAttempt, contentAttempt?.assessment, error)
             }
         } else {
-            fetchLatestAttempt(attemptsUrl: url, type: Attempt.self, filter: { $0.state == Constants.STATE_RUNNING }) { attempt, error in
+            fetchAttempt(attemptsUrl: url, type: Attempt.self, filter: { $0.state == Constants.STATE_RUNNING }) { attempt, error in
                 completion(nil, attempt, error)
             }
         }
     }
-
-
 }

--- a/CourseKit/Source/Repostories/AttemptRepository.swift
+++ b/CourseKit/Source/Repostories/AttemptRepository.swift
@@ -106,4 +106,46 @@ public class AttemptRepository {
                 completion(attempt, error)
         })
     }
+
+    private func fetchRunningAttempt(attemptsUrl: String, completion: @escaping (Attempt?, TPError?) -> Void) {
+        TPApiClient.loadAttempts(endpointProvider: TPEndpointProvider(.loadAttempts, url: attemptsUrl)) { response, error in
+            if let error = error {
+                completion(nil, error)
+                return
+            }
+            let runningAttempt = response?.results.first(where: { $0.state == Constants.STATE_RUNNING })
+            completion(runningAttempt, nil)
+        }
+    }
+
+    private func fetchContentRunningAttempt(attemptsUrl: String, completion: @escaping (ContentAttempt?, TPError?) -> Void) {
+        TPApiClient.getListItems(endpointProvider: TPEndpointProvider(.loadAttempts, url: attemptsUrl), completion: { (response: TPApiResponse<ContentAttempt>?, error: TPError?) in
+            if let error = error {
+                completion(nil, error)
+                return
+            }
+            let runningContentAttempt = response?.results.first(where: { $0.assessment?.state == Constants.STATE_RUNNING })
+            completion(runningContentAttempt, nil)
+        }, type: ContentAttempt.self)
+    }
+
+    public func fetchLatestRunningAttempt(exam: Exam, content: Content?, completion: @escaping (ContentAttempt?, Attempt?, TPError?) -> Void) {
+        let url = content?.getAttemptsUrl() ?? exam.attemptsUrl
+        guard !url.isEmpty else {
+            completion(nil, nil, nil)
+            return
+        }
+
+        if content != nil {
+            fetchContentRunningAttempt(attemptsUrl: url) { ca, error in
+                completion(ca, ca?.assessment, error)
+            }
+        } else {
+            fetchRunningAttempt(attemptsUrl: url) { a, error in
+                completion(nil, a, error)
+            }
+        }
+    }
+
+
 }

--- a/CourseKit/Source/Repostories/AttemptRepository.swift
+++ b/CourseKit/Source/Repostories/AttemptRepository.swift
@@ -107,16 +107,16 @@ public class AttemptRepository {
         })
     }
 
-    private func fetchAttempt<T: TestpressModel>(attemptsUrl: String, type: T.Type, queryParams: [String: String] = [:], completion: @escaping (T?, TPError?) -> Void) {
-        TPApiClient.getListItems(endpointProvider: TPEndpointProvider(.loadAttempts, url: attemptsUrl, queryParams: queryParams), completion: { (response: TPApiResponse<T>?, error: TPError?) in
-            if let error = error {
-                completion(nil, error)
-                return
-            }
-
-            let attempt = response?.results.first
-            completion(attempt, nil)
-        }, type: T.self)
+    private func fetchAttempts<T: TestpressModel>(attemptsUrl: String,type: T.Type,queryParams: [String: String] = [:],completion: @escaping ([T]?, TPError?) -> Void) {
+        TPApiClient.getListItems(endpointProvider: TPEndpointProvider(.loadAttempts,url: attemptsUrl,queryParams: queryParams),completion: { (response: TPApiResponse<T>?, error: TPError?) in
+                if let error = error {
+                    completion(nil, error)
+                    return
+                }
+                completion(response?.results, nil)
+            },
+            type: T.self
+        )
     }
 
     public func fetchRunningAttempt(exam: Exam, content: Content?, completion: @escaping (ContentAttempt?, Attempt?, TPError?) -> Void) {
@@ -127,12 +127,13 @@ public class AttemptRepository {
         }
 
         if content != nil {
-            fetchAttempt(attemptsUrl: url, type: ContentAttempt.self, queryParams: [Constants.STATE: "paused"]) { contentAttempt, error in
+            fetchAttempts(attemptsUrl: url, type: ContentAttempt.self, queryParams: [Constants.STATE: "paused"]) { attempts, error in
+                let contentAttempt = attempts?.first
                 completion(contentAttempt, contentAttempt?.assessment, error)
             }
         } else {
-            fetchAttempt(attemptsUrl: url, type: Attempt.self, queryParams: [Constants.STATE: "paused"]) { attempt, error in
-                completion(nil, attempt, error)
+            fetchAttempts(attemptsUrl: url, type: Attempt.self, queryParams: [Constants.STATE: "paused"]) { attempts, error in
+                completion(nil, attempts?.first, error)
             }
         }
     }

--- a/CourseKit/Source/Repostories/AttemptRepository.swift
+++ b/CourseKit/Source/Repostories/AttemptRepository.swift
@@ -107,26 +107,15 @@ public class AttemptRepository {
         })
     }
 
-    private func fetchRunningAttempt(attemptsUrl: String, completion: @escaping (Attempt?, TPError?) -> Void) {
-        TPApiClient.loadAttempts(endpointProvider: TPEndpointProvider(.loadAttempts, url: attemptsUrl)) { response, error in
+    private func fetchLatestAttempt<T: TestpressModel>(attemptsUrl: String, type: T.Type, filter: @escaping (T) -> Bool, completion: @escaping (T?, TPError?) -> Void) {
+        TPApiClient.getListItems(endpointProvider: TPEndpointProvider(.loadAttempts, url: attemptsUrl), completion: { (response: TPApiResponse<T>?, error: TPError?) in
             if let error = error {
                 completion(nil, error)
                 return
             }
-            let runningAttempt = response?.results.first(where: { $0.state == Constants.STATE_RUNNING })
-            completion(runningAttempt, nil)
-        }
-    }
-
-    private func fetchContentRunningAttempt(attemptsUrl: String, completion: @escaping (ContentAttempt?, TPError?) -> Void) {
-        TPApiClient.getListItems(endpointProvider: TPEndpointProvider(.loadAttempts, url: attemptsUrl), completion: { (response: TPApiResponse<ContentAttempt>?, error: TPError?) in
-            if let error = error {
-                completion(nil, error)
-                return
-            }
-            let runningContentAttempt = response?.results.first(where: { $0.assessment?.state == Constants.STATE_RUNNING })
-            completion(runningContentAttempt, nil)
-        }, type: ContentAttempt.self)
+            let latestAttempt = response?.results.first(where: filter)
+            completion(latestAttempt, nil)
+        }, type: T.self)
     }
 
     public func fetchLatestRunningAttempt(exam: Exam, content: Content?, completion: @escaping (ContentAttempt?, Attempt?, TPError?) -> Void) {
@@ -137,11 +126,11 @@ public class AttemptRepository {
         }
 
         if content != nil {
-            fetchContentRunningAttempt(attemptsUrl: url) { contentAttempt, error in
+            fetchLatestAttempt(attemptsUrl: url, type: ContentAttempt.self, filter: { $0.assessment?.state == Constants.STATE_RUNNING }) { contentAttempt, error in
                 completion(contentAttempt, contentAttempt?.assessment, error)
             }
         } else {
-            fetchRunningAttempt(attemptsUrl: url) { attempt, error in
+            fetchLatestAttempt(attemptsUrl: url, type: Attempt.self, filter: { $0.state == Constants.STATE_RUNNING }) { attempt, error in
                 completion(nil, attempt, error)
             }
         }

--- a/CourseKit/Source/UI/ViewControllers/StartExamScreenViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/StartExamScreenViewController.swift
@@ -110,7 +110,7 @@ public class StartExamScreenViewController: BaseUIViewController {
             webOnlyExamLabel.isHidden = true
             UIUtils.setButtonDropShadow(startButton)
             updateResumeUI()
-            attemptRepository.fetchLatestRunningAttempt(exam: exam, content: content) { [weak self] contentAttempt, attempt, error in
+            attemptRepository.fetchRunningAttempt(exam: exam, content: content) { [weak self] contentAttempt, attempt, error in
                 guard let self = self, error == nil else { return }
                 self.contentAttempt = contentAttempt
                 self.attempt = contentAttempt?.assessment ?? attempt

--- a/CourseKit/Source/UI/ViewControllers/StartExamScreenViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/StartExamScreenViewController.swift
@@ -58,6 +58,7 @@ public class StartExamScreenViewController: BaseUIViewController {
     public var exam: Exam!
     public var attempt: Attempt?
     public var accessCode: String!
+    private let attemptRepository = AttemptRepository()
     
     public override func viewDidLoad() {
         super.viewDidLoad()
@@ -108,9 +109,12 @@ public class StartExamScreenViewController: BaseUIViewController {
         } else {
             webOnlyExamLabel.isHidden = true
             UIUtils.setButtonDropShadow(startButton)
-            if attempt?.state! == Constants.STATE_RUNNING {
-                startButton.setTitle("RESUME", for: .normal)
-                navigationBarItem?.title = Strings.RESUME_EXAM
+            updateResumeUI()
+            attemptRepository.fetchLatestRunningAttempt(exam: exam, content: content) { [weak self] ca, a, _ in
+                guard let self = self else { return }
+                self.contentAttempt = ca
+                self.attempt = ca?.assessment ?? a
+                self.updateResumeUI()
             }
         }
         initializeLanguageSelection()
@@ -376,6 +380,13 @@ public class StartExamScreenViewController: BaseUIViewController {
         viewController.contentAttempt = contentAttempt
         viewController.exam = content.exam
         present(viewController, animated: true, completion: nil)
+    }
+
+    private func updateResumeUI() {
+        if attempt?.state == Constants.STATE_RUNNING {
+            startButton.setTitle("RESUME", for: .normal)
+            navigationBarItem?.title = Strings.RESUME_EXAM
+        }
     }
     
     // Set frames of the views in this method to support both portrait & landscape view

--- a/CourseKit/Source/UI/ViewControllers/StartExamScreenViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/StartExamScreenViewController.swift
@@ -110,10 +110,10 @@ public class StartExamScreenViewController: BaseUIViewController {
             webOnlyExamLabel.isHidden = true
             UIUtils.setButtonDropShadow(startButton)
             updateResumeUI()
-            attemptRepository.fetchLatestRunningAttempt(exam: exam, content: content) { [weak self] ca, a, _ in
-                guard let self = self else { return }
-                self.contentAttempt = ca
-                self.attempt = ca?.assessment ?? a
+            attemptRepository.fetchLatestRunningAttempt(exam: exam, content: content) { [weak self] contentAttempt, attempt, error in
+                guard let self = self, error == nil else { return }
+                self.contentAttempt = contentAttempt
+                self.attempt = contentAttempt?.assessment ?? attempt
                 self.updateResumeUI()
             }
         }
@@ -386,6 +386,9 @@ public class StartExamScreenViewController: BaseUIViewController {
         if attempt?.state == Constants.STATE_RUNNING {
             startButton.setTitle("RESUME", for: .normal)
             navigationBarItem?.title = Strings.RESUME_EXAM
+        } else {
+            startButton.setTitle("START", for: .normal)
+            navigationBarItem?.title = exam.title
         }
     }
     


### PR DESCRIPTION
Local attempt state could become outdated and display an incorrect START or RESUME action.
The app relied on cached attempt data instead of validating the latest running attempt from the backend.
Added running attempt synchronization logic and refreshed the resume UI using the latest server state during screen load.