### PR TITLE
fix: show PDF download option when enabled

### DIFF
--- a/CourseKit/Source/UI/ViewControllers/AttachmentDetailViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/AttachmentDetailViewController.swift
@@ -68,10 +68,12 @@ class AttachmentDetailViewController: BaseUIViewController, URLSessionDownloadDe
         initializeBookmarkHelper()
         showTitleAndDescription()
         addShadowToButtons()
+        guard let attachment = content.attachment else { return }
 
-        if (content.attachment?.isRenderable == true) {
+        if attachment.isRenderable {
             showViewButton()
-        } else {
+        }
+        if attachment.allowDownload {
             showDownloadButton()
         }
         session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)

--- a/CourseKit/Source/UI/ViewControllers/AttachmentDetailViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/AttachmentDetailViewController.swift
@@ -65,10 +65,10 @@ class AttachmentDetailViewController: BaseUIViewController, URLSessionDownloadDe
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        guard let attachment = content.attachment else { return }
         initializeBookmarkHelper()
         showTitleAndDescription()
         addShadowToButtons()
-        guard let attachment = content.attachment else { return }
 
         if attachment.isRenderable {
             showViewButton()


### PR DESCRIPTION
- The PDF download option was not visible in iOS even when enabled.
- The download field was not handled in iOS.
- Updated iOS PDF handling to show download option when enabled.