### PR TITLE
fix: Resolve retake exam failure for completed attempts

### DIFF
--- a/CourseKit/Source/Repostories/AttemptRepository.swift
+++ b/CourseKit/Source/Repostories/AttemptRepository.swift
@@ -137,14 +137,14 @@ public class AttemptRepository {
         )
     }
 
-    public func fetchRunningAttempt(exam: Exam, content: Content?, completion: @escaping (ContentAttempt?, Attempt?, TPError?) -> Void) {
+    public func fetchRunningAttempt(exam: Exam, completion: @escaping (Attempt?, TPError?) -> Void) {
         guard !exam.attemptsUrl.isEmpty else {
-            completion(nil, nil, nil)
+            completion(nil, nil)
             return
         }
 
         fetchAttempts(attemptsUrl: exam.attemptsUrl, type: Attempt.self, queryParams: [Constants.STATE: "paused"]) { attempts, error in
-            completion(nil, attempts?.first, error)
+            completion(attempts?.first, error)
         }
     }
 

--- a/CourseKit/Source/Repostories/AttemptRepository.swift
+++ b/CourseKit/Source/Repostories/AttemptRepository.swift
@@ -138,21 +138,13 @@ public class AttemptRepository {
     }
 
     public func fetchRunningAttempt(exam: Exam, content: Content?, completion: @escaping (ContentAttempt?, Attempt?, TPError?) -> Void) {
-        let url = content?.getAttemptsUrl() ?? exam.attemptsUrl
-        guard !url.isEmpty else {
+        guard !exam.attemptsUrl.isEmpty else {
             completion(nil, nil, nil)
             return
         }
 
-        if content != nil {
-            fetchAttempts(attemptsUrl: url, type: ContentAttempt.self, queryParams: [Constants.STATE: "paused"]) { attempts, error in
-                let contentAttempt = attempts?.first
-                completion(contentAttempt, contentAttempt?.assessment, error)
-            }
-        } else {
-            fetchAttempts(attemptsUrl: url, type: Attempt.self, queryParams: [Constants.STATE: "paused"]) { attempts, error in
-                completion(nil, attempts?.first, error)
-            }
+        fetchAttempts(attemptsUrl: exam.attemptsUrl, type: Attempt.self, queryParams: [Constants.STATE: "paused"]) { attempts, error in
+            completion(nil, attempts?.first, error)
         }
     }
 

--- a/CourseKit/Source/UI/ViewControllers/StartExamScreenViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/StartExamScreenViewController.swift
@@ -110,10 +110,10 @@ public class StartExamScreenViewController: BaseUIViewController {
             webOnlyExamLabel.isHidden = true
             UIUtils.setButtonDropShadow(startButton)
             updateResumeUI()
-            attemptRepository.fetchRunningAttempt(exam: exam, content: content) { [weak self] contentAttempt, attempt, error in
+            attemptRepository.fetchRunningAttempt(exam: exam) { [weak self] attempt, error in
                 guard let self = self, error == nil else { return }
-                self.contentAttempt = contentAttempt
-                self.attempt = contentAttempt?.assessment ?? attempt
+                self.contentAttempt = nil
+                self.attempt = attempt
                 self.updateResumeUI()
             }
         }


### PR DESCRIPTION
- Retaking completed exams showed a “loading failed” error
- Content attempt endpoint ignored the state=paused query parameter
- Updated running attempt check to use the exam attempts endpoint supporting paused state filtering

