### PR TITLE
fix: Add missing Zoom bundle copy step in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
           curl -L -s -o zoom-sdk.zip "${{ env.ZOOM_SDK_URL }}"
           unzip -q zoom-sdk.zip -d zoom_temp
           cp -R zoom_temp/*.xcframework Carthage/Build/ || true
+          cp -R zoom_temp/*.bundle Carthage/Build/ || true
           rm -rf zoom_temp zoom-sdk.zip
         timeout-minutes: 40
 


### PR DESCRIPTION
* Add the missing Zoom bundle copy step to the release workflow
* The Zoom button was completely unresponsive because the Zoom SDK bundle was not being copied into the app binary, resulting in Zoom support being unavailable in the app
* This fix ensures the Zoom bundle is correctly included in the app binary, restoring Zoom functionality as expected
