### PR TITLE
fix: Prevent incorrect permission error during exam retake

### DIFF
--- a/CourseKit/Source/Database/Models/ContentPermission.swift
+++ b/CourseKit/Source/Database/Models/ContentPermission.swift
@@ -1,0 +1,21 @@
+//
+//  ContentPermission.swift
+//  CourseKit
+//
+//  Copyright © 2024 Testpress. All rights reserved.
+//
+
+import Foundation
+import ObjectMapper
+
+public class ContentPermission: TestpressModel {
+    public var hasPermission: Bool = false
+    public var nextRetakeTime: String?
+
+    public required init?(map: Map) {}
+
+    public func mapping(map: Map) {
+        hasPermission <- map["has_permission"]
+        nextRetakeTime <- map["next_retake_time"]
+    }
+}

--- a/CourseKit/Source/Repostories/AttemptRepository.swift
+++ b/CourseKit/Source/Repostories/AttemptRepository.swift
@@ -148,4 +148,10 @@ public class AttemptRepository {
         }
     }
 
+    public func checkContentPermission(contentId: Int, completion: @escaping (ContentPermission?, TPError?) -> Void) {
+        let url = TestpressCourse.shared.baseURL + "/api/v2.2/contents/\(contentId)/permissions/"
+        TPApiClient.request(type: ContentPermission.self, endpointProvider: TPEndpointProvider(.get, url: url)) { permission, error in
+            completion(permission, error)
+        }
+    }
 }

--- a/CourseKit/Source/UI/ViewControllers/StartExamScreenViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/StartExamScreenViewController.swift
@@ -122,7 +122,10 @@ public class StartExamScreenViewController: BaseUIViewController {
                     guard let self = self else { return }
                     self.hideLoading()
 
-                    guard let permission = permission, error == nil else { return }
+                    guard let permission = permission, error == nil else {
+                        self.startButtonLayout.isHidden = false
+                        return
+                    }
 
                     if !permission.hasPermission {
                         self.webOnlyExamLabel.isHidden = false
@@ -196,7 +199,12 @@ public class StartExamScreenViewController: BaseUIViewController {
                     } else {
                         self.exam.updateLanguages(with: self.languages)
                         self.languageContainer.isHidden = self.languages.count < 2
-                        if self.content?.id == nil {
+                        let isPermissionCheckPending = self.content?.id != nil &&
+                            self.exam?.deviceAccessControl != "web" &&
+                            !(self.content?.isLocked ?? false) &&
+                            self.exam.hasStarted() &&
+                            !self.exam.hasEnded()
+                        if !isPermissionCheckPending {
                             self.hideLoading()
                         }
                     }

--- a/CourseKit/Source/UI/ViewControllers/StartExamScreenViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/StartExamScreenViewController.swift
@@ -116,6 +116,27 @@ public class StartExamScreenViewController: BaseUIViewController {
                 self.attempt = attempt
                 self.updateResumeUI()
             }
+            if let examId = content?.id {
+                startButtonLayout.isHidden = true
+                attemptRepository.checkContentPermission(contentId: examId) { [weak self] permission, error in
+                    guard let self = self else { return }
+                    self.hideLoading()
+
+                    guard let permission = permission, error == nil else { return }
+
+                    if !permission.hasPermission {
+                        self.webOnlyExamLabel.isHidden = false
+                        self.webOnlyExamLabel.text = Strings.EXAM_NO_PERMISSION
+                    } else if let time = permission.nextRetakeTime,
+                              time != "0",
+                              let timeDiff = FormatDate.getTimeDifference(iso8601String: time) {
+                        self.webOnlyExamLabel.isHidden = false
+                        self.webOnlyExamLabel.text = String(format: Strings.CAN_RETAKE_IN, timeDiff.lowercased())
+                    } else {
+                        self.startButtonLayout.isHidden = false
+                    }
+                }
+            }
         }
         initializeLanguageSelection()
     }
@@ -175,7 +196,9 @@ public class StartExamScreenViewController: BaseUIViewController {
                     } else {
                         self.exam.updateLanguages(with: self.languages)
                         self.languageContainer.isHidden = self.languages.count < 2
-                        self.hideLoading()
+                        if self.content?.id == nil {
+                            self.hideLoading()
+                        }
                     }
     
             }, type: Language.self)

--- a/CourseKit/Source/Utils/FormatDate.swift
+++ b/CourseKit/Source/Utils/FormatDate.swift
@@ -140,4 +140,16 @@ public class FormatDate {
         }
         return nil
     }
+
+    public static func getTimeDifference(iso8601String: String) -> String? {
+        guard let date = getDate(from: iso8601String), date > Date() else { return nil }
+
+        if date.timeIntervalSinceNow < 60 { return "less than a minute" }
+
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.weekOfYear, .day, .hour, .minute]
+        formatter.unitsStyle = .full
+        formatter.maximumUnitCount = 1
+        return formatter.string(from: Date(), to: date)
+    }
 }

--- a/CourseKit/Source/Utils/Strings.swift
+++ b/CourseKit/Source/Utils/Strings.swift
@@ -133,8 +133,10 @@ public struct Strings {
     public static let TARGETS_AND_THREATS = "TARGETS / THREATS"
     
     public static let EXAM_ENDED = "This exam has ended"
+    public static let EXAM_NO_PERMISSION = "You do not have permission to perform this action."
     public static let CAN_START_EXAM_ONLY_AFTER = "You can attempt this exam only after \n"
     public static let SCORE_GOOD_IN_PREVIOUS = "You need to get good score in your previous test to attempt this."
+    public static let CAN_RETAKE_IN = "You can retake this exam in %@. Meanwhile review your previous attempt."
     
     public static let RESET_PASSWORD_MAIL_SENT = "We have sent you an email with a link to reset your password.  Please check your email and click the link to continue."
     

--- a/ios-app.xcodeproj/project.pbxproj
+++ b/ios-app.xcodeproj/project.pbxproj
@@ -331,6 +331,7 @@
 		25FF2A9D2525E566005A31C5 /* TestZoomMeetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25FF2A9C2525E566005A31C5 /* TestZoomMeetViewController.swift */; };
 		2D0658F12FBB524E00FCB43B /* ExamReviewRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0658F02FBB524E00FCB43B /* ExamReviewRouter.swift */; };
 		2D6B7F9C2F6A6D5A00A0C362 /* DeepLinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D6B7F9B2F6A6D5A00A0C362 /* DeepLinkRouter.swift */; };
+		2D78B7BF2FC71046002EEE84 /* ContentPermission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D78B7BE2FC71046002EEE84 /* ContentPermission.swift */; };
 		2D7CDBCC2F237CCD0076B42F /* URLRequest+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7CDBCB2F237CCD0076B42F /* URLRequest+Extension.swift */; };
 		2D7CDBCE2F237D150076B42F /* DeviceIDManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7CDBCD2F237D150076B42F /* DeviceIDManager.swift */; };
 		2D84D0662F433CE1000EF4DC /* UnauthorizedDeviceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D84D0652F433CE1000EF4DC /* UnauthorizedDeviceViewController.swift */; };
@@ -599,6 +600,7 @@
 		25FF2A9C2525E566005A31C5 /* TestZoomMeetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestZoomMeetViewController.swift; sourceTree = "<group>"; };
 		2D0658F02FBB524E00FCB43B /* ExamReviewRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExamReviewRouter.swift; sourceTree = "<group>"; };
 		2D6B7F9B2F6A6D5A00A0C362 /* DeepLinkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkRouter.swift; sourceTree = "<group>"; };
+		2D78B7BE2FC71046002EEE84 /* ContentPermission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentPermission.swift; sourceTree = "<group>"; };
 		2D7CDBCB2F237CCD0076B42F /* URLRequest+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Extension.swift"; sourceTree = "<group>"; };
 		2D7CDBCD2F237D150076B42F /* DeviceIDManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceIDManager.swift; sourceTree = "<group>"; };
 		2D84D0652F433CE1000EF4DC /* UnauthorizedDeviceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnauthorizedDeviceViewController.swift; sourceTree = "<group>"; };
@@ -1080,6 +1082,7 @@
 				D907E7A82B19D11C00BEA874 /* Language.swift */,
 				2F96997D1FC2A761001B2B18 /* Attachment.swift */,
 				2FC0F2C31F86385B0092BFDC /* Attempt.swift */,
+				2D78B7BE2FC71046002EEE84 /* ContentPermission.swift */,
 				2FC0F2C41F86385B0092BFDC /* AttemptAnswer.swift */,
 				2FC0F2C51F86385B0092BFDC /* AttemptItem.swift */,
 				1825F5FC212E8BF900AC25E5 /* AttemptSection.swift */,
@@ -2158,6 +2161,7 @@
 				03CD0D282CB92C0700E17218 /* BaseDBTableViewController.swift in Sources */,
 				03CD0C502CB79C5400E17218 /* GraphAxisPercentValueFormatter.swift in Sources */,
 				03CD0C6F2CB7C5FD00E17218 /* UIView.swift in Sources */,
+				2D78B7BF2FC71046002EEE84 /* ContentPermission.swift in Sources */,
 				03A60F8C2CB3F34600079A7C /* BaseDBItemPager.swift in Sources */,
 				03A60F9D2CB3F6A900079A7C /* OrderedDictionary.swift in Sources */,
 				038CB2B22CBD278600164127 /* HtmlContentViewController.swift in Sources */,


### PR DESCRIPTION
- fix incorrect “You do not have permission” message shown when users try to retake an exam during the retake interval period
- previously iOS did not validate the content permission API before starting the exam, unlike Android
- add content permission check before exam start to properly handle retake interval restrictions
- show the correct retake wait time message based on the permission API response

