### PR TITLE
fix: Prevent index-out-of-range crash after completing first exam attempt

### DIFF
--- a/CourseKit/Source/UI/ViewControllers/ContentDetailPageViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/ContentDetailPageViewController.swift
@@ -336,10 +336,15 @@ public class ContentDetailPageViewController: BaseUIViewController, UIPageViewCo
 
     private func updateContentData(_ content: Content) {
         DBManager<Content>().addData(object: content)
-        contents[getCurrentIndex()] = content
+        let currentIndex = getCurrentIndex()
+        guard currentIndex >= 0, currentIndex < contents.count else {
+            return
+        }
+
+        contents[currentIndex] = content
         contentDetailDataSource.contents = contents
         
-        guard let viewController = contentDetailDataSource.viewControllerAtIndex(getCurrentIndex()) else {
+        guard let viewController = contentDetailDataSource.viewControllerAtIndex(currentIndex) else {
             return
         }
         

--- a/CourseKit/Source/UI/ViewControllers/ContentExamAttemptsTableViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/ContentExamAttemptsTableViewController.swift
@@ -255,6 +255,7 @@ class ContentExamAttemptsTableViewController: UITableViewController {
             Constants.START_EXAM_SCREEN_VIEW_CONTROLLER) as! StartExamScreenViewController
         
         viewController.content = content
+        viewController.content.index = content.index
         if contentAttempt != nil {
             viewController.contentAttempt = contentAttempt
         }


### PR DESCRIPTION
- Users taking an exam for the first time could see the app crash after the exam finished when they tapped back.
- The app was still trying to refresh the current page even though the page index for that first-attempt flow was no longer valid.
- We preserved the correct page state and added a safety check so returning back after the first attempt no longer crashes.
