### PR TITLE
feat: Show waiting screen for videos still being transcoded

### DIFF
--- a/CourseKit/Source/Database/DBManager.swift
+++ b/CourseKit/Source/Database/DBManager.swift
@@ -38,7 +38,7 @@ public class DBConnection {
     
     public static func configure(){
          var config = Realm.Configuration(
-            schemaVersion:6,
+            schemaVersion:7,
             migrationBlock: { migration, oldSchemaVersion in
             }
          )

--- a/CourseKit/Source/Database/Models/Video.swift
+++ b/CourseKit/Source/Database/Models/Video.swift
@@ -27,12 +27,17 @@ import ObjectMapper
 import Foundation
 import RealmSwift
 
+public enum TranscodingStatus: String {
+    case completed = "completed"
+    case notTranscoded = "not transcoded video"
+}
 
 public class Video: DBModel {
     @objc dynamic public var url: String = ""
     @objc dynamic public var title: String = ""
     @objc dynamic public var embedCode: String = ""
     @objc dynamic public var duration: String = ""
+    @objc dynamic public var transcodingStatus: String?
 
     public var streams = List<Stream>()
     
@@ -52,6 +57,14 @@ public class Video: DBModel {
         }
     }
     
+    public var isTranscodingComplete: Bool {
+        guard let status = transcodingStatus?.lowercased() else {
+            return true
+        }
+        return status == TranscodingStatus.completed.rawValue
+            || status == TranscodingStatus.notTranscoded.rawValue
+    }
+    
     override public static func primaryKey() -> String? {
         return "id"
     }
@@ -64,5 +77,6 @@ public class Video: DBModel {
         embedCode <- map["embed_code"]
         streams <- (map["streams"], ListTransform<Stream>())
         duration <- (map["duration"], StringTransform())
+        transcodingStatus <- map["transcoding_status"]
     }
 }

--- a/CourseKit/Source/UI/ViewControllers/Base/EmptyView.swift
+++ b/CourseKit/Source/UI/ViewControllers/Base/EmptyView.swift
@@ -96,6 +96,13 @@ public class EmptyView: UIView {
         isHidden = true
         parentView.sendSubviewToBack(self)
     }
+    
+    public func setProcessingStyle() {
+        imageView.isHidden = true
+        backgroundColor = UIColor.black
+        emptyViewDescription.textColor = .white
+        retryButton.setTitleColor(.white, for: .normal)
+    }
 
     @IBAction func onRetry(_ sender: UIButton) {
         if retryHandler != nil {

--- a/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
@@ -80,18 +80,17 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
     
     private func handleTranscodingStatus() {
         let status = content.video?.transcodingStatus?.lowercased()
-        debugPrint("=== Transcoding status: \(content.video?.transcodingStatus ?? "nil"), video: \(content.video != nil)")
 
         if status == TranscodingStatus.completed.rawValue
             || status == TranscodingStatus.notTranscoded.rawValue {
             guard let uuid = content.uuid else { return }
             loadPlayer(assetID: uuid)
         } else if status == nil {
-            // Status unknown — list endpoint doesn't include it. Show overlay + auto-check.
-            showProcessingOverlay()
+            // Unknown — play immediately, verify in background
+            guard let uuid = content.uuid else { return }
+            loadPlayer(assetID: uuid)
             performTranscodingCheck()
         } else {
-            // Explicitly processing — show overlay, user taps retry
             showProcessingOverlay()
         }
     }
@@ -223,9 +222,19 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
         
         let isComplete = updatedContent.video?.isTranscodingComplete ?? true
         if !isComplete {
+            // Started playing assuming complete, but API says still processing — show overlay instead
+            player?.pause()
+            player = nil
+            playerViewController?.willMove(toParent: nil)
+            playerViewController?.view.removeFromSuperview()
+            playerViewController?.removeFromParent()
+            playerViewController = nil
+            showProcessingOverlay()
             return
         }
         
+        // Only load player if overlay was showing (retry path). Auto-check path already playing.
+        guard processingEmptyView != nil else { return }
         processingEmptyView?.hide()
         guard let uuid = updatedContent.uuid else { return }
         loadPlayer(assetID: uuid)

--- a/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
@@ -79,11 +79,19 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
     }
     
     private func handleTranscodingStatus() {
-        let isComplete = content.video?.isTranscodingComplete ?? true
-        if isComplete {
+        let status = content.video?.transcodingStatus?.lowercased()
+        debugPrint("=== Transcoding status: \(content.video?.transcodingStatus ?? "nil"), video: \(content.video != nil)")
+
+        if status == TranscodingStatus.completed.rawValue
+            || status == TranscodingStatus.notTranscoded.rawValue {
             guard let uuid = content.uuid else { return }
             loadPlayer(assetID: uuid)
+        } else if status == nil {
+            // Status unknown — list endpoint doesn't include it. Show overlay + auto-check.
+            showProcessingOverlay()
+            performTranscodingCheck()
         } else {
+            // Explicitly processing — show overlay, user taps retry
             showProcessingOverlay()
         }
     }
@@ -157,14 +165,21 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
     
     func retryProcessingCheck() {
         let indicator = showRetryLoadingIndicator()
+        performTranscodingCheck {
+            self.hideRetryLoadingIndicator(indicator)
+        }
+    }
+    
+    func performTranscodingCheck(completion: (() -> Void)? = nil) {
+        let requestedContentId = content.id
         
         TPApiClient.request(
             type: Content.self,
             endpointProvider: TPEndpointProvider(.get, url: content.getUrl()),
             completion: { [weak self] content, error in
                 guard let self = self else { return }
-                self.hideRetryLoadingIndicator(indicator)
-                self.handleTranscodingCheckResult(content: content, error: error)
+                completion?()
+                self.handleTranscodingCheckResult(requestedContentId: requestedContentId, content: content, error: error)
             }
         )
     }
@@ -192,7 +207,9 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
         processingEmptyView?.retryButton.setTitleColor(.white, for: .normal)
     }
     
-    private func handleTranscodingCheckResult(content: Content?, error: TPError?) {
+    private func handleTranscodingCheckResult(requestedContentId: Int, content: Content?, error: TPError?) {
+        guard requestedContentId == self.content.id else { return }
+        
         if let error = error {
             debugPrint(error.message ?? "No error")
             debugPrint(error.kind)
@@ -202,8 +219,10 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
         
         guard let updatedContent = content else { return }
         
+        debugPrint("=== Retry API response - transcodingStatus: \(updatedContent.video?.transcodingStatus ?? "nil")")
+        
         DBManager<Content>().addData(object: updatedContent)
-        self.content = updatedContent
+        self.content = DBManager<Content>().getResultsFromDB().filter("id == %d", updatedContent.id).first
         
         let isComplete = updatedContent.video?.isTranscodingComplete ?? true
         if !isComplete {
@@ -376,8 +395,6 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
     
     deinit {
         player?.removeObserver(self, forKeyPath: "rate")
-        processingEmptyView?.removeFromSuperview()
-        processingEmptyView = nil
     }
 
     @objc func updateVideoAttempt() {

--- a/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
@@ -150,6 +150,7 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
     func showProcessingOverlay() {
         removeExistingOverlay()
         processingEmptyView = EmptyView.getInstance(parentView: playerView)
+        processingEmptyView?.setProcessingStyle()
         processingEmptyView?.show(
             description: "The video is being processed and will be available shortly.",
             retryButtonText: "Retry",
@@ -157,10 +158,6 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
                 self?.retryProcessingCheck()
             }
         )
-        processingEmptyView?.imageView.isHidden = true
-        processingEmptyView?.backgroundColor = UIColor.black
-        processingEmptyView?.emptyViewDescription.textColor = .white
-        processingEmptyView?.retryButton.setTitleColor(.white, for: .normal)
     }
     
     func retryProcessingCheck() {
@@ -222,7 +219,7 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
         debugPrint("=== Retry API response - transcodingStatus: \(updatedContent.video?.transcodingStatus ?? "nil")")
         
         DBManager<Content>().addData(object: updatedContent)
-        self.content = DBManager<Content>().getResultsFromDB().filter("id == %d", updatedContent.id).first
+        applyTranscodingContent(updatedContent)
         
         let isComplete = updatedContent.video?.isTranscodingComplete ?? true
         if !isComplete {
@@ -232,6 +229,12 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
         processingEmptyView?.hide()
         guard let uuid = updatedContent.uuid else { return }
         loadPlayer(assetID: uuid)
+    }
+    
+    private func applyTranscodingContent(_ newContent: Content) {
+        self.content = DBManager<Content>().getResultsFromDB().filter("id == %d", newContent.id).first
+        viewModel.content = self.content
+        bookmarkContent = self.content
     }
     
     private func showErrorSnackbar(message: String) {

--- a/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
@@ -96,8 +96,8 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
                 loadPlayer(assetID: uuid)
             } else {
                 showProcessingOverlay()
+                performTranscodingCheck()
             }
-            performTranscodingCheck()
         } else {
             showProcessingOverlay()
         }

--- a/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
@@ -86,8 +86,17 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
             guard let uuid = content.uuid else { return }
             loadPlayer(assetID: uuid)
         } else if status == nil {
-            // Unknown (list endpoint doesn't include transcoding_status) — show overlay, verify via API
-            showProcessingOverlay()
+            guard let uuid = content.uuid else { return }
+            
+            let isDownloaded = TPStreamsDownloadManager.shared.isAssetDownloaded(assetID: uuid)
+            let hasStreams = !(content.video?.streams.isEmpty ?? true)
+            let hasValidUrl = !(content.video?.url.isEmpty ?? true)
+            
+            if isDownloaded || hasStreams || hasValidUrl {
+                loadPlayer(assetID: uuid)
+            } else {
+                showProcessingOverlay()
+            }
             performTranscodingCheck()
         } else {
             showProcessingOverlay()

--- a/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
@@ -60,7 +60,7 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
         super.viewDidLoad()
         
         instituteSettings = DBManager<InstituteSettings>().getResultsFromDB().first
-        handleTranscodingStatus()
+        checkTranscodingStatusAndLoadPlayer()
         viewModel = VideoContentViewModel(content)
         titleLabel.text = viewModel.getTitle()
         initializeDescription()
@@ -78,7 +78,7 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
         addGestures()
     }
     
-    private func handleTranscodingStatus() {
+    private func checkTranscodingStatusAndLoadPlayer() {
         let status = content.video?.transcodingStatus?.lowercased()
 
         if status == TranscodingStatus.completed.rawValue
@@ -421,7 +421,7 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
         hideDescription()
         viewModel.createContentAttempt()
         removeExistingOverlay()
-        handleTranscodingStatus()
+        checkTranscodingStatusAndLoadPlayer()
         tableView.reloadData()
         titleLabel.text = viewModel.getTitle()
         desc.text = viewModel.getDescription()

--- a/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
@@ -86,9 +86,8 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
             guard let uuid = content.uuid else { return }
             loadPlayer(assetID: uuid)
         } else if status == nil {
-            // Unknown — play immediately, verify in background
-            guard let uuid = content.uuid else { return }
-            loadPlayer(assetID: uuid)
+            // Unknown (list endpoint doesn't include transcoding_status) — show overlay, verify via API
+            showProcessingOverlay()
             performTranscodingCheck()
         } else {
             showProcessingOverlay()

--- a/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
@@ -44,6 +44,7 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
     var position: Int! = 0
     var player: TPAVPlayer?
     var playerViewController: TPStreamPlayerViewController?
+    var processingEmptyView: EmptyView?
     
     @IBOutlet weak var playerView: UIView!
     @IBOutlet weak var titleLabel: UILabel!
@@ -59,7 +60,7 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
         super.viewDidLoad()
         
         instituteSettings = DBManager<InstituteSettings>().getResultsFromDB().first
-        loadPlayer(assetID: content.uuid!)
+        handleTranscodingStatus()
         viewModel = VideoContentViewModel(content)
         titleLabel.text = viewModel.getTitle()
         initializeDescription()
@@ -77,6 +78,16 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
         addGestures()
     }
     
+    private func handleTranscodingStatus() {
+        let isComplete = content.video?.isTranscodingComplete ?? true
+        if isComplete {
+            guard let uuid = content.uuid else { return }
+            loadPlayer(assetID: uuid)
+        } else {
+            showProcessingOverlay()
+        }
+    }
+
     func loadPlayer(assetID: String) {
         initializePlayer(with: assetID)
         configurePlayerViewController()
@@ -126,6 +137,92 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
         addChild(playerViewController)
         playerView.addSubview(playerViewController.view)
         playerViewController.view.frame = playerView.bounds
+    }
+    
+    func showProcessingOverlay() {
+        removeExistingOverlay()
+        processingEmptyView = EmptyView.getInstance(parentView: playerView)
+        processingEmptyView?.show(
+            description: "The video is being processed and will be available shortly.",
+            retryButtonText: "Retry",
+            retryHandler: { [weak self] in
+                self?.retryProcessingCheck()
+            }
+        )
+        processingEmptyView?.imageView.isHidden = true
+        processingEmptyView?.backgroundColor = UIColor.black
+        processingEmptyView?.emptyViewDescription.textColor = .white
+        processingEmptyView?.retryButton.setTitleColor(.white, for: .normal)
+    }
+    
+    func retryProcessingCheck() {
+        let indicator = showRetryLoadingIndicator()
+        
+        TPApiClient.request(
+            type: Content.self,
+            endpointProvider: TPEndpointProvider(.get, url: content.getUrl()),
+            completion: { [weak self] content, error in
+                guard let self = self else { return }
+                self.hideRetryLoadingIndicator(indicator)
+                self.handleTranscodingCheckResult(content: content, error: error)
+            }
+        )
+    }
+    
+    private func showRetryLoadingIndicator() -> UIActivityIndicatorView {
+        processingEmptyView?.retryButton.isEnabled = false
+        
+        let indicator = UIActivityIndicatorView(style: .white)
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        indicator.startAnimating()
+        if let emptyView = processingEmptyView {
+            emptyView.addSubview(indicator)
+            NSLayoutConstraint.activate([
+                indicator.centerXAnchor.constraint(equalTo: emptyView.retryButton.centerXAnchor),
+                indicator.centerYAnchor.constraint(equalTo: emptyView.retryButton.centerYAnchor)
+            ])
+            emptyView.retryButton.setTitleColor(.clear, for: .normal)
+        }
+        return indicator
+    }
+    
+    private func hideRetryLoadingIndicator(_ indicator: UIActivityIndicatorView) {
+        indicator.removeFromSuperview()
+        processingEmptyView?.retryButton.isEnabled = true
+        processingEmptyView?.retryButton.setTitleColor(.white, for: .normal)
+    }
+    
+    private func handleTranscodingCheckResult(content: Content?, error: TPError?) {
+        if let error = error {
+            debugPrint(error.message ?? "No error")
+            debugPrint(error.kind)
+            showErrorSnackbar(message: "Could not check video status. Please try again.")
+            return
+        }
+        
+        guard let updatedContent = content else { return }
+        
+        DBManager<Content>().addData(object: updatedContent)
+        self.content = updatedContent
+        
+        let isComplete = updatedContent.video?.isTranscodingComplete ?? true
+        if !isComplete {
+            return
+        }
+        
+        processingEmptyView?.hide()
+        guard let uuid = updatedContent.uuid else { return }
+        loadPlayer(assetID: uuid)
+    }
+    
+    private func showErrorSnackbar(message: String) {
+        let snackbar = TTGSnackbar(message: message, duration: .middle)
+        snackbar.show()
+    }
+    
+    private func removeExistingOverlay() {
+        processingEmptyView?.removeFromSuperview()
+        processingEmptyView = nil
     }
     
     func initializeDescription() {
@@ -279,6 +376,8 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
     
     deinit {
         player?.removeObserver(self, forKeyPath: "rate")
+        processingEmptyView?.removeFromSuperview()
+        processingEmptyView = nil
     }
 
     @objc func updateVideoAttempt() {
@@ -293,7 +392,8 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
         viewModel.content = content
         hideDescription()
         viewModel.createContentAttempt()
-        loadPlayer(assetID: content.uuid!)
+        removeExistingOverlay()
+        handleTranscodingStatus()
         tableView.reloadData()
         titleLabel.text = viewModel.getTitle()
         desc.text = viewModel.getDescription()
@@ -383,7 +483,7 @@ extension VideoContentViewController: VideoContentViewModelDelegate {
             return
         }
         let seekTime = CMTime(value: Int64(seconds), timescale: 1)
+
         player?.seek(to: seekTime, toleranceBefore: CMTime.zero, toleranceAfter: CMTime.zero)
     }
-    
 }


### PR DESCRIPTION
- Users saw a blank player when opening a video that had not finished transcoding, with no indication of what was happening.
- The player was loaded immediately regardless of the video's transcoding progress.
- A waiting screen is now shown while a video is still being transcoded, with a retry option to check when playback is available.