### PR TITLE
feat: support custom forgot password URL

### DIFF
--- a/CourseKit/Source/Database/DBManager.swift
+++ b/CourseKit/Source/Database/DBManager.swift
@@ -38,7 +38,7 @@ public class DBConnection {
     
     public static func configure(){
          var config = Realm.Configuration(
-            schemaVersion:7,
+            schemaVersion:8,
             migrationBlock: { migration, oldSchemaVersion in
             }
          )

--- a/CourseKit/Source/Database/Models/InstituteSettings.swift
+++ b/CourseKit/Source/Database/Models/InstituteSettings.swift
@@ -75,6 +75,7 @@ public class InstituteSettings: DBModel {
     @objc public dynamic var salesforceMarketingCloudUrl: String? = nil
     @objc public dynamic var salesforceMid: String? = nil
     @objc public dynamic var allowProfileEdit: Bool = true
+    @objc public dynamic var customForgotPasswordUrl: String? = nil
 
     public var allowedLoginMethods = List<Int>()
     
@@ -136,6 +137,7 @@ public class InstituteSettings: DBModel {
         salesforceMarketingCloudUrl <- map["salesforce_marketing_cloud_url"]
         salesforceMid <- map["salesforce_mid"]
         allowProfileEdit <- map["allow_profile_edit"]
+        customForgotPasswordUrl <- map["custom_forgot_password_url"]
         var tempAllowed: [Int] = []
         tempAllowed <- map["allowed_login_methods"]
 

--- a/ios-app/UI/LoginViewController.swift
+++ b/ios-app/UI/LoginViewController.swift
@@ -201,10 +201,16 @@ class LoginViewController: BaseTextFieldViewController, DeepLinkBaseProtocol {
     }
     
     @IBAction func showResetPasswordView() {
-        let tabViewController = self.storyboard?.instantiateViewController(withIdentifier:
-            Constants.RESET_PASSWORD_VIEW_CONTROLLER) as! ResetPasswordViewController
-        
-        present(tabViewController, animated: true, completion: nil)
+        if let customUrlString = instituteSettings.customForgotPasswordUrl,
+           let customUrl = URL(string: customUrlString),
+           UIApplication.shared.canOpenURL(customUrl) {
+            UIApplication.shared.open(customUrl, options: [:], completionHandler: nil)
+        } else {
+            let tabViewController = self.storyboard?.instantiateViewController(withIdentifier:
+                Constants.RESET_PASSWORD_VIEW_CONTROLLER) as! ResetPasswordViewController
+            
+            present(tabViewController, animated: true, completion: nil)
+        }
     }
     
     @objc func closeAlert(gesture: UITapGestureRecognizer) {

--- a/ios-app/UI/LoginViewController.swift
+++ b/ios-app/UI/LoginViewController.swift
@@ -201,16 +201,26 @@ class LoginViewController: BaseTextFieldViewController, DeepLinkBaseProtocol {
     }
     
     @IBAction func showResetPasswordView() {
-        if let customUrlString = instituteSettings.customForgotPasswordUrl,
+        if let customUrlString = instituteSettings?.customForgotPasswordUrl,
+           !customUrlString.isEmpty,
            let customUrl = URL(string: customUrlString),
+           (customUrl.scheme == "http" || customUrl.scheme == "https"),
            UIApplication.shared.canOpenURL(customUrl) {
-            UIApplication.shared.open(customUrl, options: [:], completionHandler: nil)
+            UIApplication.shared.open(customUrl, options: [:]) { success in
+                if !success {
+                    self.showNativeResetPassword()
+                }
+            }
         } else {
-            let tabViewController = self.storyboard?.instantiateViewController(withIdentifier:
-                Constants.RESET_PASSWORD_VIEW_CONTROLLER) as! ResetPasswordViewController
-            
-            present(tabViewController, animated: true, completion: nil)
+            showNativeResetPassword()
         }
+    }
+    
+    private func showNativeResetPassword() {
+        let tabViewController = self.storyboard?.instantiateViewController(withIdentifier:
+            Constants.RESET_PASSWORD_VIEW_CONTROLLER) as! ResetPasswordViewController
+        
+        present(tabViewController, animated: true, completion: nil)
     }
     
     @objc func closeAlert(gesture: UITapGestureRecognizer) {


### PR DESCRIPTION
- Allows institutes to configure a custom forgot password URL.
- Opens the configured URL when users tap "Forgot Password".
- Falls back to the existing in-app reset password flow when no custom URL is configured.