### PR TITLE
feat: Add Content Artifacts bottom sheet for downloading resources

### DIFF
--- a/CourseKit/Source/Database/DBManager.swift
+++ b/CourseKit/Source/Database/DBManager.swift
@@ -38,7 +38,7 @@ public class DBConnection {
     
     public static func configure(){
          var config = Realm.Configuration(
-            schemaVersion:8,
+            schemaVersion:9,
             migrationBlock: { migration, oldSchemaVersion in
             }
          )

--- a/CourseKit/Source/Database/Models/Content.swift
+++ b/CourseKit/Source/Database/Models/Content.swift
@@ -67,6 +67,7 @@ public class Content: DBModel {
     @objc dynamic public var coverImageSmall: String!
     @objc dynamic public var coverImageMedium: String!
     @objc dynamic public var hasEnded: Bool = false
+    @objc dynamic public var hasArtifacts: Bool = false
     @objc dynamic public var uuid: String?
 
     
@@ -107,6 +108,7 @@ public class Content: DBModel {
         coverImageSmall <- map["cover_image_small"]
         coverImageMedium <- map["cover_image_medium"]
         hasEnded <- map["has_ended"]
+        hasArtifacts <- map["has_artifacts"]
         end <- map["end"]
         uuid <- map["uuid"]
     }

--- a/CourseKit/Source/Network/Endpoints/TPEndpoint.swift
+++ b/CourseKit/Source/Network/Endpoints/TPEndpoint.swift
@@ -82,7 +82,6 @@ public enum TPEndpoint {
     case checkEnforceDataCollectionStatus
     case generateOtp
     case otpLogin
-    case contentArtifacts
 
     public var method: Alamofire.HTTPMethod {
         switch self {
@@ -130,8 +129,7 @@ public enum TPEndpoint {
              .bookmarks,
              .bookmarkFolders,
              .getActivityFeed,
-             .checkEnforceDataCollectionStatus,
-             .contentArtifacts:
+             .checkEnforceDataCollectionStatus:
             return .get
         case .get:
             return .get
@@ -252,8 +250,6 @@ public enum TPEndpoint {
             return "/api/v2.5/auth/generate-otp/"
         case .otpLogin:
             return "/api/v2.5/auth/otp-login/"
-        case .contentArtifacts:
-            return ""
         default:
             return ""
         }

--- a/CourseKit/Source/Network/Endpoints/TPEndpoint.swift
+++ b/CourseKit/Source/Network/Endpoints/TPEndpoint.swift
@@ -82,6 +82,7 @@ public enum TPEndpoint {
     case checkEnforceDataCollectionStatus
     case generateOtp
     case otpLogin
+    case contentArtifacts
 
     public var method: Alamofire.HTTPMethod {
         switch self {
@@ -129,7 +130,8 @@ public enum TPEndpoint {
              .bookmarks,
              .bookmarkFolders,
              .getActivityFeed,
-             .checkEnforceDataCollectionStatus:
+             .checkEnforceDataCollectionStatus,
+             .contentArtifacts:
             return .get
         case .get:
             return .get
@@ -250,6 +252,8 @@ public enum TPEndpoint {
             return "/api/v2.5/auth/generate-otp/"
         case .otpLogin:
             return "/api/v2.5/auth/otp-login/"
+        case .contentArtifacts:
+            return ""
         default:
             return ""
         }
@@ -326,5 +330,9 @@ public struct TPEndpointProvider {
     
     public static func getCourseDetailUrl(courseId: Int) -> String {
         return TestpressCourse.shared.baseURL + TPEndpoint.getCourses.urlPath + "\(courseId)/"
+    }
+
+    public static func getContentArtifactsUrl(contentId: Int) -> String {
+        return TestpressCourse.shared.baseURL + "/api/v3/contents/\(contentId)/artifacts/"
     }
 }

--- a/CourseKit/Source/Network/Models/Artifact.swift
+++ b/CourseKit/Source/Network/Models/Artifact.swift
@@ -1,0 +1,24 @@
+//
+//  Artifact.swift
+//  CourseKit
+//
+//  Copyright © 2024 Testpress. All rights reserved.
+//
+
+import ObjectMapper
+
+public class Artifact: Mappable {
+    public var id: Int = 0
+    public var name: String = ""
+    public var url: String = ""
+    public var accessibleWithoutAttempt: Bool = true
+
+    public required init?(map: Map) {}
+
+    public func mapping(map: Map) {
+        id <- map["id"]
+        name <- map["name"]
+        url <- map["url"]
+        accessibleWithoutAttempt <- map["accessible_without_attempt"]
+    }
+}

--- a/CourseKit/Source/UI/StoryBoards/Course.storyboard
+++ b/CourseKit/Source/UI/StoryBoards/Course.storyboard
@@ -2662,6 +2662,55 @@
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="art-tv">
                                 <rect key="frame" x="0.0" y="203" width="393" height="649"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="ArtifactCell" rowHeight="-1" estimatedRowHeight="-1" id="art-cell" customClass="ArtifactCell" customModule="CourseKit">
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="art-cell" id="art-cv">
+                                            <rect key="frame" x="0.0" y="0.0" width="393" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="art-fiv">
+                                                    <rect key="frame" x="16" y="10" width="24" height="24"/>
+                                                    <color key="tintColor" systemColor="systemGrayColor"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="24" id="c-fiv-w"/>
+                                                        <constraint firstAttribute="height" constant="24" id="c-fiv-h"/>
+                                                    </constraints>
+                                                </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="art-tl">
+                                                    <rect key="frame" x="52" y="12" width="281" height="20"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </imageView>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="art-riv">
+                                                    <rect key="frame" x="353" y="10" width="24" height="24"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="24" id="c-riv-w"/>
+                                                        <constraint firstAttribute="height" constant="24" id="c-riv-h"/>
+                                                    </constraints>
+                                                </imageView>
+                                            </subviews>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <constraints>
+                                                <constraint firstItem="art-fiv" firstAttribute="leading" secondItem="art-cv" secondAttribute="leading" constant="16" id="c-fiv-l"/>
+                                                <constraint firstItem="art-fiv" firstAttribute="centerY" secondItem="art-tl" secondAttribute="centerY" id="c-fiv-y"/>
+                                                <constraint firstItem="art-tl" firstAttribute="leading" secondItem="art-fiv" secondAttribute="trailing" constant="12" id="c-tl-l"/>
+                                                <constraint firstItem="art-tl" firstAttribute="top" secondItem="art-cv" secondAttribute="top" constant="12" id="c-tl-t"/>
+                                                <constraint firstItem="art-tl" firstAttribute="bottom" secondItem="art-cv" secondAttribute="bottom" constant="-12" id="c-tl-b"/>
+                                                <constraint firstItem="art-tl" firstAttribute="trailing" secondItem="art-riv" secondAttribute="leading" constant="-8" id="c-tl-r"/>
+                                                <constraint firstItem="art-riv" firstAttribute="trailing" secondItem="art-cv" secondAttribute="trailing" constant="-16" id="c-riv-r"/>
+                                                <constraint firstItem="art-riv" firstAttribute="centerY" secondItem="art-tl" secondAttribute="centerY" id="c-riv-y"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="fileIconView" destination="art-fiv" id="con-fiv"/>
+                                            <outlet property="titleLabel" destination="art-tl" id="con-tl"/>
+                                            <outlet property="rightIconView" destination="art-riv" id="con-riv"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </prototypes>
                             </tableView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No resources available" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="art-el">
                                 <rect key="frame" x="114.66666666666667" y="441.33333333333331" width="163.66666666666663" height="19.333333333333314"/>

--- a/CourseKit/Source/UI/StoryBoards/Course.storyboard
+++ b/CourseKit/Source/UI/StoryBoards/Course.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="24506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24504"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
@@ -28,7 +28,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9ba-At-CKh">
-                                <rect key="frame" x="0.0" y="59" width="393" height="44"/>
+                                <rect key="frame" x="0.0" y="118" width="393" height="54"/>
                                 <items>
                                     <navigationItem title="Chapters" id="QBU-Hq-9ft">
                                         <barButtonItem key="leftBarButtonItem" image="ic_navigate_before_36pt" style="done" id="L8b-k0-oyb">
@@ -41,7 +41,7 @@
                                 </items>
                             </navigationBar>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="f8R-uS-EYU">
-                                <rect key="frame" x="0.0" y="103" width="393" height="715"/>
+                                <rect key="frame" x="0.0" y="172" width="393" height="612"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="32" minimumInteritemSpacing="30" id="cmF-kq-TdZ">
                                     <size key="itemSize" width="108" height="114"/>
@@ -351,7 +351,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qPo-JR-9GP">
-                                <rect key="frame" x="0.0" y="59" width="393" height="44"/>
+                                <rect key="frame" x="0.0" y="118" width="393" height="54"/>
                                 <items>
                                     <navigationItem title="Content Detail" id="Ig2-6W-SOY">
                                         <barButtonItem key="leftBarButtonItem" image="ic_navigate_before_36pt" style="done" id="WDa-lZ-pR4">
@@ -364,7 +364,7 @@
                                 </items>
                             </navigationBar>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DNz-g6-dIr">
-                                <rect key="frame" x="0.0" y="103" width="393" height="715"/>
+                                <rect key="frame" x="0.0" y="172" width="393" height="612"/>
                             </containerView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="PYt-cJ-ihF"/>
@@ -393,7 +393,7 @@
             <objects>
                 <navigationController storyboardIdentifier="ContentsListNavigationController" modalPresentationStyle="fullScreen" id="HFy-lA-eXJ" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="Bi9-od-CEL">
-                        <rect key="frame" x="0.0" y="59" width="393" height="44"/>
+                        <rect key="frame" x="0.0" y="118" width="393" height="54"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -622,7 +622,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bC9-Gf-lRW">
-                                <rect key="frame" x="0.0" y="59" width="393" height="44"/>
+                                <rect key="frame" x="0.0" y="118" width="393" height="54"/>
                                 <items>
                                     <navigationItem title="Content Detail" id="E4C-2g-tsL">
                                         <barButtonItem key="leftBarButtonItem" image="ic_navigate_before_36pt" style="done" id="eGe-R0-Fva">
@@ -640,17 +640,17 @@
                                 </items>
                             </navigationBar>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2Eq-Dj-xz4">
-                                <rect key="frame" x="0.0" y="103" width="393" height="665"/>
+                                <rect key="frame" x="0.0" y="172" width="393" height="562"/>
                             </containerView>
                             <view alpha="0.10000000149011612" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mKx-8f-odD">
-                                <rect key="frame" x="0.0" y="760" width="393" height="8"/>
+                                <rect key="frame" x="0.0" y="726" width="393" height="8"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="8" id="OSF-LV-5lh"/>
                                 </constraints>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dwI-Hh-LXX">
-                                <rect key="frame" x="0.0" y="768" width="393" height="50"/>
+                                <rect key="frame" x="0.0" y="734" width="393" height="50"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hT7-nN-0CY">
                                         <rect key="frame" x="0.0" y="0.0" width="393" height="50"/>
@@ -758,7 +758,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HLS-Rc-1EC">
-                                <rect key="frame" x="0.0" y="59" width="393" height="759"/>
+                                <rect key="frame" x="0.0" y="118" width="393" height="666"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="elp-0m-ZNY">
                                         <rect key="frame" x="0.0" y="0.0" width="393" height="453"/>
@@ -850,7 +850,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hR3-vG-R7O">
-                                                                <rect key="frame" x="105.66666666666669" y="46.333333333333343" width="142" height="20"/>
+                                                                <rect key="frame" x="105.66666666666669" y="46.333333333333314" width="142" height="20"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="142" id="Xmx-Le-Orj"/>
                                                                     <constraint firstAttribute="height" constant="20" id="ob7-7N-7zj"/>
@@ -866,7 +866,7 @@
                                                                 </connections>
                                                             </button>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4Jz-Ut-GEd">
-                                                                <rect key="frame" x="105.66666666666669" y="86.333333333333343" width="142" height="20"/>
+                                                                <rect key="frame" x="105.66666666666669" y="86.333333333333314" width="142" height="20"/>
                                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="20" id="P3a-Ma-2Ut"/>
@@ -1011,7 +1011,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ecP-Ra-sch">
-                                <rect key="frame" x="0.0" y="59" width="393" height="759"/>
+                                <rect key="frame" x="0.0" y="118" width="393" height="666"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vhU-md-pQY">
                                         <rect key="frame" x="0.0" y="0.0" width="393" height="453"/>
@@ -1039,7 +1039,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="w8Q-dK-fe4">
-                                                        <rect key="frame" x="36.666666666666657" y="60.333333333333314" width="270" height="229"/>
+                                                        <rect key="frame" x="36.666666666666657" y="60.333333333333343" width="270" height="229.00000000000003"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="5QG-ez-zed">
                                                                 <rect key="frame" x="0.0" y="0.0" width="270" height="18"/>
@@ -1069,7 +1069,7 @@
                                                                 </subviews>
                                                             </stackView>
                                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="q7c-v2-yyM">
-                                                                <rect key="frame" x="0.0" y="38.000000000000014" width="270" height="18"/>
+                                                                <rect key="frame" x="0.0" y="38" width="270" height="18"/>
                                                                 <subviews>
                                                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="testpress_duration" translatesAutoresizingMaskIntoConstraints="NO" id="ufK-61-3bn">
                                                                         <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
@@ -1096,7 +1096,7 @@
                                                                 </subviews>
                                                             </stackView>
                                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="BEt-bs-fYy">
-                                                                <rect key="frame" x="0.0" y="76.000000000000014" width="270" height="18"/>
+                                                                <rect key="frame" x="0.0" y="76" width="270" height="18"/>
                                                                 <subviews>
                                                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="testpress_marks" translatesAutoresizingMaskIntoConstraints="NO" id="cOH-h7-BVr">
                                                                         <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
@@ -1123,7 +1123,7 @@
                                                                 </subviews>
                                                             </stackView>
                                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="VcK-9O-6Ug">
-                                                                <rect key="frame" x="0.0" y="114.00000000000001" width="270" height="17.999999999999986"/>
+                                                                <rect key="frame" x="0.0" y="113.99999999999997" width="270" height="18"/>
                                                                 <subviews>
                                                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="testpress_negative" translatesAutoresizingMaskIntoConstraints="NO" id="zzh-q4-esQ">
                                                                         <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
@@ -1150,7 +1150,7 @@
                                                                 </subviews>
                                                             </stackView>
                                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Jv6-xc-Oed">
-                                                                <rect key="frame" x="0.0" y="152" width="270" height="18"/>
+                                                                <rect key="frame" x="0.0" y="151.99999999999997" width="270" height="18"/>
                                                                 <subviews>
                                                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="testpress_calendar_icon" translatesAutoresizingMaskIntoConstraints="NO" id="pZj-M8-Oxg">
                                                                         <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
@@ -1180,7 +1180,7 @@
                                                                 </subviews>
                                                             </stackView>
                                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="ZoM-ua-Yq3">
-                                                                <rect key="frame" x="0.0" y="190" width="270" height="18"/>
+                                                                <rect key="frame" x="0.0" y="189.99999999999997" width="270" height="18"/>
                                                                 <subviews>
                                                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="language_icon" translatesAutoresizingMaskIntoConstraints="NO" id="pd8-T1-LNZ">
                                                                         <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
@@ -1210,7 +1210,7 @@
                                                                 </subviews>
                                                             </stackView>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kqM-Tq-UG9">
-                                                                <rect key="frame" x="0.0" y="228" width="270" height="1"/>
+                                                                <rect key="frame" x="0.0" y="227.99999999999997" width="270" height="1"/>
                                                                 <color key="backgroundColor" red="0.90196078430000004" green="0.90196078430000004" blue="0.90196078430000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="1" id="bZ6-XG-B0x"/>
@@ -1251,7 +1251,7 @@
                                                                 </subviews>
                                                             </stackView>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Hs-kR-FfZ">
-                                                                <rect key="frame" x="0.0" y="112.33333333333337" width="343" height="30"/>
+                                                                <rect key="frame" x="0.0" y="112.33333333333331" width="343" height="30"/>
                                                                 <color key="backgroundColor" red="0.0" green="0.80000000000000004" blue="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <fontDescription key="fontDescription" name="Rubik-Medium" family="Rubik" pointSize="15"/>
                                                                 <state key="normal" title="START">
@@ -1340,7 +1340,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RhB-Uc-UQL">
-                                <rect key="frame" x="0.0" y="59" width="393" height="759"/>
+                                <rect key="frame" x="0.0" y="118" width="393" height="666"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="q61-Wm-POS">
                                         <rect key="frame" x="0.0" y="0.0" width="393" height="270"/>
@@ -1368,7 +1368,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="kHU-mV-opm">
-                                                        <rect key="frame" x="36.666666666666657" y="60.333333333333329" width="270" height="76.999999999999986"/>
+                                                        <rect key="frame" x="36.666666666666657" y="60.333333333333343" width="270" height="77"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Y7w-AQ-poA">
                                                                 <rect key="frame" x="0.0" y="0.0" width="270" height="18"/>
@@ -1398,7 +1398,7 @@
                                                                 </subviews>
                                                             </stackView>
                                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Xo3-uQ-p3H">
-                                                                <rect key="frame" x="0.0" y="38.000000000000014" width="270" height="18"/>
+                                                                <rect key="frame" x="0.0" y="38" width="270" height="18"/>
                                                                 <subviews>
                                                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="testpress_calendar_icon" translatesAutoresizingMaskIntoConstraints="NO" id="3ow-0B-1w0">
                                                                         <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
@@ -1428,7 +1428,7 @@
                                                                 </subviews>
                                                             </stackView>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="p1l-4e-HaZ">
-                                                                <rect key="frame" x="0.0" y="76.000000000000014" width="270" height="1"/>
+                                                                <rect key="frame" x="0.0" y="76" width="270" height="1"/>
                                                                 <color key="backgroundColor" red="0.90196078430000004" green="0.90196078430000004" blue="0.90196078430000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="1" id="V0b-1a-3h7"/>
@@ -1449,13 +1449,13 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="This exam can only be attempt on the website." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="S7Y-pq-TaX">
-                                                                <rect key="frame" x="20.333333333333343" y="36.666666666666657" width="302.33333333333326" height="16.666666666666671"/>
+                                                                <rect key="frame" x="20.333333333333343" y="36.666666666666686" width="302.33333333333326" height="16.666666666666671"/>
                                                                 <fontDescription key="fontDescription" name="Rubik-Regular" family="Rubik" pointSize="14"/>
                                                                 <color key="textColor" red="0.90196078430000004" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="bottom" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="pe5-Fo-ucV">
-                                                                <rect key="frame" x="111.66666666666666" y="73.333333333333343" width="120" height="19"/>
+                                                                <rect key="frame" x="111.66666666666666" y="73.333333333333371" width="120" height="19"/>
                                                                 <subviews>
                                                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_thumb_up_18pt" translatesAutoresizingMaskIntoConstraints="NO" id="gt9-r7-EZS">
                                                                         <rect key="frame" x="0.0" y="1" width="18" height="18"/>
@@ -1469,7 +1469,7 @@
                                                                 </subviews>
                                                             </stackView>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LMa-NJ-Giw">
-                                                                <rect key="frame" x="0.0" y="112.33333333333334" width="343" height="30"/>
+                                                                <rect key="frame" x="0.0" y="112.33333333333337" width="343" height="30"/>
                                                                 <color key="backgroundColor" red="0.0" green="0.80000000000000004" blue="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <fontDescription key="fontDescription" name="Rubik-Medium" family="Rubik" pointSize="15"/>
                                                                 <state key="normal" title="START">
@@ -1501,7 +1501,7 @@
                                         </constraints>
                                     </view>
                                     <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Ce-KL-7wY">
-                                        <rect key="frame" x="0.0" y="270" width="393" height="523"/>
+                                        <rect key="frame" x="0.0" y="270" width="393" height="464"/>
                                     </containerView>
                                 </subviews>
                                 <constraints>
@@ -1866,7 +1866,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CaD-kb-e4I">
-                                <rect key="frame" x="0.0" y="59" width="393" height="759"/>
+                                <rect key="frame" x="0.0" y="118" width="393" height="666"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2fi-47-SuT">
                                         <rect key="frame" x="0.0" y="0.0" width="393" height="453"/>
@@ -1891,7 +1891,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8W4-eC-JUx">
-                                                                <rect key="frame" x="101.66666666666669" y="46.333333333333329" width="150" height="1"/>
+                                                                <rect key="frame" x="101.66666666666669" y="46.333333333333343" width="150" height="1"/>
                                                                 <color key="backgroundColor" red="0.80000000000000004" green="0.80000000000000004" blue="0.80000000000000004" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="150" id="9Ae-mc-6XS"/>
@@ -1955,7 +1955,7 @@
                                                                                         <nil key="highlightedColor"/>
                                                                                     </label>
                                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="START DATE" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dau-sa-Exn">
-                                                                                        <rect key="frame" x="0.0" y="23.333333333333314" width="68" height="15"/>
+                                                                                        <rect key="frame" x="0.0" y="23.333333333333343" width="68" height="15"/>
                                                                                         <constraints>
                                                                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="66.5" id="Lvl-Nk-VrA"/>
                                                                                             <constraint firstAttribute="height" constant="15" id="Wrm-iV-Sgp"/>
@@ -2022,7 +2022,7 @@
                                                                                         <nil key="highlightedColor"/>
                                                                                     </label>
                                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="START TIME" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="F62-a4-mxL">
-                                                                                        <rect key="frame" x="0.0" y="23.333333333333314" width="66.333333333333329" height="15"/>
+                                                                                        <rect key="frame" x="0.0" y="23.333333333333343" width="66.333333333333329" height="15"/>
                                                                                         <constraints>
                                                                                             <constraint firstAttribute="height" constant="15" id="ecS-tZ-QRb"/>
                                                                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="66.5" id="l26-IY-ioW"/>
@@ -2209,7 +2209,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4n9-xn-txU">
-                                <rect key="frame" x="0.0" y="59" width="393" height="44"/>
+                                <rect key="frame" x="0.0" y="118" width="393" height="54"/>
                                 <items>
                                     <navigationItem title="Zoom Meet" id="Glq-FW-q7j">
                                         <barButtonItem key="leftBarButtonItem" image="ic_navigate_before_36pt" style="done" id="LqX-cT-qLM">
@@ -2222,7 +2222,7 @@
                                 </items>
                             </navigationBar>
                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pdt-Pk-zui">
-                                <rect key="frame" x="0.0" y="103" width="393" height="645"/>
+                                <rect key="frame" x="0.0" y="172" width="393" height="542"/>
                             </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="fUE-07-vnc"/>
@@ -2254,11 +2254,11 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aYd-GV-zb1" userLabel="PDFView" customClass="PDFView">
-                                <rect key="frame" x="0.0" y="103" width="393" height="715"/>
+                                <rect key="frame" x="0.0" y="162" width="393" height="622"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mfv-Zs-Xo0">
-                                <rect key="frame" x="0.0" y="59" width="393" height="44"/>
+                                <rect key="frame" x="0.0" y="108" width="393" height="54"/>
                                 <items>
                                     <navigationItem title="Title" id="ph8-2L-TDJ" userLabel="Navigation Bar Item">
                                         <barButtonItem key="leftBarButtonItem" image="ic_navigate_before_36pt" style="done" id="d0l-K9-MYN" userLabel="Back">
@@ -2300,11 +2300,11 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0cK-UU-fUD" userLabel="VideoPlayer View">
-                                <rect key="frame" x="0.0" y="58.999999999999986" width="393" height="255.66666666666663"/>
+                                <rect key="frame" x="0.0" y="117.99999999999999" width="393" height="255.66666666666663"/>
                                 <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aaX-XG-5mZ">
-                                <rect key="frame" x="0.0" y="314.66666666666674" width="393" height="503.33333333333326"/>
+                                <rect key="frame" x="0.0" y="373.66666666666674" width="393" height="410.33333333333326"/>
                             </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="GB0-0e-9cQ"/>
@@ -2366,24 +2366,24 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="CourseTableViewCell" id="l7G-yD-20h" customClass="CourseTableViewCell" customModule="CourseKit">
-                                <rect key="frame" x="0.0" y="50" width="393" height="112.33333587646484"/>
+                                <rect key="frame" x="0.0" y="50" width="393" height="113"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="l7G-yD-20h" id="xNx-b0-9Eb">
-                                    <rect key="frame" x="0.0" y="0.0" width="393" height="112.33333587646484"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="393" height="113"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="1z0-bH-WDF">
-                                            <rect key="frame" x="20" y="4" width="373" height="104.33333333333333"/>
+                                            <rect key="frame" x="20" y="4" width="373" height="105"/>
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="tp_exam_icon" translatesAutoresizingMaskIntoConstraints="NO" id="Uc8-5x-xCj">
-                                                    <rect key="frame" x="0.0" y="20" width="64" height="64.333333333333329"/>
+                                                    <rect key="frame" x="0.0" y="20" width="64" height="65"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="64" id="Ftf-db-6ih"/>
                                                         <constraint firstAttribute="height" constant="64" id="VyU-HG-9Y4"/>
                                                     </constraints>
                                                 </imageView>
                                                 <stackView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="cJs-xj-E0c">
-                                                    <rect key="frame" x="74" y="2.6666666666666643" width="299" height="99"/>
+                                                    <rect key="frame" x="74" y="3" width="299" height="99"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label vLabel Label Label Label Label Label Label Label " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2fO-VA-kib">
                                                             <rect key="frame" x="0.0" y="0.0" width="299" height="38"/>
@@ -2425,7 +2425,7 @@
                                                                     <rect key="contentStretch" x="0.0" y="0.0" width="0.0" height="1"/>
                                                                 </stackView>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Valid till 24 Feb, 2024" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ix5-8V-0yk">
-                                                                    <rect key="frame" x="0.0" y="20.333333333333329" width="299" height="14.333333333333336"/>
+                                                                    <rect key="frame" x="0.0" y="20.333333333333343" width="299" height="14.333333333333336"/>
                                                                     <accessibility key="accessibilityConfiguration">
                                                                         <accessibilityTraits key="traits" image="YES" staticText="YES"/>
                                                                     </accessibility>
@@ -2496,13 +2496,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NLT-vM-MQD">
-                                <rect key="frame" x="0.0" y="59" width="393" height="759"/>
+                                <rect key="frame" x="0.0" y="118" width="393" height="666"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="5f8-i3-ort">
-                                        <rect key="frame" x="16" y="0.0" width="361" height="759"/>
+                                        <rect key="frame" x="16" y="0.0" width="361" height="666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Looks like you-ve not downloaded any videos as of now." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UoM-Df-oKo">
-                                                <rect key="frame" x="0.0" y="0.0" width="361" height="759"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="361" height="666"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -2619,12 +2619,93 @@
             </objects>
             <point key="canvasLocation" x="-1187.0229007633586" y="-516.19718309859161"/>
         </scene>
+        <!--Artifact List View Controller-->
+        <scene sceneID="ART-SCENE">
+            <objects>
+                <viewController storyboardIdentifier="ArtifactListViewController" id="art-vc" customClass="ArtifactListViewController" customModule="CourseKit" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="art-view">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="art-dh">
+                                <rect key="frame" x="176.66666666666666" y="126" width="40" height="5"/>
+                                <color key="backgroundColor" red="0.81960784313725488" green="0.81960784313725488" blue="0.83921568627450982" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="5" id="dh-h"/>
+                                    <constraint firstAttribute="width" constant="40" id="dh-w"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <real key="value" value="2.5"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </view>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Resources" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="art-ht">
+                                <rect key="frame" x="16" y="147" width="361" height="22"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Access your study materials" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="art-hs">
+                                <rect key="frame" x="16" y="173" width="361" height="17"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <color key="textColor" red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="art-dv">
+                                <rect key="frame" x="0.0" y="202" width="393" height="1"/>
+                                <color key="backgroundColor" red="0.8784313725490196" green="0.8784313725490196" blue="0.8784313725490196" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="1" id="dv-h"/>
+                                </constraints>
+                            </view>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="art-tv">
+                                <rect key="frame" x="0.0" y="203" width="393" height="649"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </tableView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No resources available" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="art-el">
+                                <rect key="frame" x="114.66666666666667" y="441.33333333333331" width="163.66666666666663" height="19.333333333333314"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                <color key="textColor" red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="art-sa"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="art-dh" firstAttribute="top" secondItem="art-sa" secondAttribute="top" constant="8" id="c-dh-t"/>
+                            <constraint firstItem="art-dh" firstAttribute="centerX" secondItem="art-sa" secondAttribute="centerX" id="c-dh-x"/>
+                            <constraint firstItem="art-dv" firstAttribute="leading" secondItem="art-view" secondAttribute="leading" id="c-dv-l"/>
+                            <constraint firstAttribute="trailing" secondItem="art-dv" secondAttribute="trailing" id="c-dv-r"/>
+                            <constraint firstItem="art-dv" firstAttribute="top" secondItem="art-hs" secondAttribute="bottom" constant="12" id="c-dv-t"/>
+                            <constraint firstItem="art-el" firstAttribute="centerX" secondItem="art-sa" secondAttribute="centerX" id="c-el-x"/>
+                            <constraint firstItem="art-el" firstAttribute="centerY" secondItem="art-sa" secondAttribute="centerY" id="c-el-y"/>
+                            <constraint firstItem="art-hs" firstAttribute="leading" secondItem="art-sa" secondAttribute="leading" constant="16" id="c-hs-l"/>
+                            <constraint firstItem="art-sa" firstAttribute="trailing" secondItem="art-hs" secondAttribute="trailing" constant="16" id="c-hs-r"/>
+                            <constraint firstItem="art-hs" firstAttribute="top" secondItem="art-ht" secondAttribute="bottom" constant="4" id="c-hs-t"/>
+                            <constraint firstItem="art-ht" firstAttribute="leading" secondItem="art-sa" secondAttribute="leading" constant="16" id="c-ht-l"/>
+                            <constraint firstItem="art-sa" firstAttribute="trailing" secondItem="art-ht" secondAttribute="trailing" constant="16" id="c-ht-r"/>
+                            <constraint firstItem="art-ht" firstAttribute="top" secondItem="art-dh" secondAttribute="bottom" constant="16" id="c-ht-t"/>
+                            <constraint firstAttribute="bottom" secondItem="art-tv" secondAttribute="bottom" id="c-tv-b"/>
+                            <constraint firstItem="art-tv" firstAttribute="leading" secondItem="art-view" secondAttribute="leading" id="c-tv-l"/>
+                            <constraint firstAttribute="trailing" secondItem="art-tv" secondAttribute="trailing" id="c-tv-r"/>
+                            <constraint firstItem="art-tv" firstAttribute="top" secondItem="art-dv" secondAttribute="bottom" id="c-tv-t"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="dividerView" destination="art-dv" id="con-dv"/>
+                        <outlet property="dragHandleView" destination="art-dh" id="con-dh"/>
+                        <outlet property="emptyLabel" destination="art-el" id="con-el"/>
+                        <outlet property="headerSubtitleLabel" destination="art-hs" id="con-hs"/>
+                        <outlet property="headerTitleLabel" destination="art-ht" id="con-ht"/>
+                        <outlet property="tableView" destination="art-tv" id="con-tv"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="art-fr" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1721" y="1908"/>
+        </scene>
     </scenes>
-    <designables>
-        <designable name="lce-lF-d6M">
-            <size key="intrinsicContentSize" width="45" height="12"/>
-        </designable>
-    </designables>
     <resources>
         <image name="calendar" width="32" height="32"/>
         <image name="caret_down" width="16" height="16"/>
@@ -2664,7 +2745,7 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="tintColor">
-            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.0" green="0.53333333333333333" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/CourseKit/Source/UI/StoryBoards/Course.storyboard
+++ b/CourseKit/Source/UI/StoryBoards/Course.storyboard
@@ -2683,7 +2683,7 @@
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
-                                                </imageView>
+                                                </label>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="art-riv">
                                                     <rect key="frame" x="353" y="10" width="24" height="24"/>
                                                     <constraints>

--- a/CourseKit/Source/UI/ViewControllers/ArtifactListViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/ArtifactListViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class ArtifactListViewController: UIViewController {
+class ArtifactListViewController: BaseUIViewController {
 
     private let tableView = UITableView()
     private let emptyLabel = UILabel()
@@ -32,6 +32,7 @@ class ArtifactListViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
+        tableView.backgroundColor = .white
         setupHeader()
         setupTableView()
         setupEmptyLabel()
@@ -90,6 +91,8 @@ class ArtifactListViewController: UIViewController {
         tableView.delegate = self
         tableView.dataSource = self
         tableView.register(ArtifactCell.self, forCellReuseIdentifier: "ArtifactCell")
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = 56
         tableView.tableFooterView = UIView()
         tableView.separatorInset = UIEdgeInsets(top: 0, left: 52, bottom: 0, right: 16)
         view.addSubview(tableView)
@@ -123,7 +126,15 @@ class ArtifactListViewController: UIViewController {
             return
         }
 
-        let fileName = artifact.name.isEmpty ? downloadUrl.lastPathComponent : "\(artifact.name).pdf"
+        let fileExtension = downloadUrl.pathExtension
+        let fileName: String
+        if artifact.name.isEmpty {
+            fileName = downloadUrl.lastPathComponent
+        } else if !fileExtension.isEmpty {
+            fileName = "\(artifact.name).\(fileExtension)"
+        } else {
+            fileName = artifact.name
+        }
 
         FileDownloadUtility.shared.downloadFile(
             viewController: self,

--- a/CourseKit/Source/UI/ViewControllers/ArtifactListViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/ArtifactListViewController.swift
@@ -1,0 +1,255 @@
+//
+//  ArtifactListViewController.swift
+//  CourseKit
+//
+//  Copyright © 2024 Testpress. All rights reserved.
+//
+
+import UIKit
+
+class ArtifactListViewController: UIViewController {
+
+    private let tableView = UITableView()
+    private let emptyLabel = UILabel()
+
+    // Bottom sheet header views
+    private let dragHandleView = UIView()
+    private let headerTitleLabel = UILabel()
+    private let headerSubtitleLabel = UILabel()
+    private let dividerView = UIView()
+
+    private var artifacts: [Artifact]
+
+    init(artifacts: [Artifact]) {
+        self.artifacts = artifacts
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        setupHeader()
+        setupTableView()
+        setupEmptyLabel()
+    }
+
+    private func setupHeader() {
+        // Drag handle
+        dragHandleView.translatesAutoresizingMaskIntoConstraints = false
+        dragHandleView.backgroundColor = .systemGray4
+        dragHandleView.layer.cornerRadius = 2.5
+        dragHandleView.clipsToBounds = true
+        view.addSubview(dragHandleView)
+
+        // Title
+        headerTitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        headerTitleLabel.text = "Resources"
+        headerTitleLabel.font = UIFont.boldSystemFont(ofSize: 18)
+        headerTitleLabel.textColor = .black
+        view.addSubview(headerTitleLabel)
+
+        // Subtitle
+        headerSubtitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        headerSubtitleLabel.text = "Access your study materials"
+        headerSubtitleLabel.font = UIFont.systemFont(ofSize: 14)
+        headerSubtitleLabel.textColor = .systemGray
+        view.addSubview(headerSubtitleLabel)
+
+        // Divider
+        dividerView.translatesAutoresizingMaskIntoConstraints = false
+        dividerView.backgroundColor = .systemGray5
+        view.addSubview(dividerView)
+
+        NSLayoutConstraint.activate([
+            dragHandleView.topAnchor.constraint(equalTo: view.topAnchor, constant: 8),
+            dragHandleView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            dragHandleView.widthAnchor.constraint(equalToConstant: 40),
+            dragHandleView.heightAnchor.constraint(equalToConstant: 5),
+
+            headerTitleLabel.topAnchor.constraint(equalTo: dragHandleView.bottomAnchor, constant: 16),
+            headerTitleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            headerTitleLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+
+            headerSubtitleLabel.topAnchor.constraint(equalTo: headerTitleLabel.bottomAnchor, constant: 4),
+            headerSubtitleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            headerSubtitleLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+
+            dividerView.topAnchor.constraint(equalTo: headerSubtitleLabel.bottomAnchor, constant: 12),
+            dividerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            dividerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            dividerView.heightAnchor.constraint(equalToConstant: 1)
+        ])
+    }
+
+    private func setupTableView() {
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.register(ArtifactCell.self, forCellReuseIdentifier: "ArtifactCell")
+        tableView.tableFooterView = UIView()
+        tableView.separatorInset = UIEdgeInsets(top: 0, left: 52, bottom: 0, right: 16)
+        view.addSubview(tableView)
+
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: dividerView.bottomAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    private func setupEmptyLabel() {
+        emptyLabel.translatesAutoresizingMaskIntoConstraints = false
+        emptyLabel.text = "No resources available"
+        emptyLabel.textAlignment = .center
+        emptyLabel.textColor = .systemGray
+        emptyLabel.font = UIFont.systemFont(ofSize: 16)
+        emptyLabel.isHidden = !artifacts.isEmpty
+        view.addSubview(emptyLabel)
+
+        NSLayoutConstraint.activate([
+            emptyLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            emptyLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+    }
+
+    private func downloadArtifact(_ artifact: Artifact) {
+        guard let downloadUrl = URL(string: artifact.url) else {
+            showError("Invalid file URL")
+            return
+        }
+
+        let fileName = artifact.name.isEmpty ? downloadUrl.lastPathComponent : "\(artifact.name).pdf"
+
+        FileDownloadUtility.shared.downloadFile(
+            viewController: self,
+            from: downloadUrl,
+            fileName: fileName,
+            completion: { [weak self] fileUrl, error in
+                if let error = error {
+                    self?.showError(error.localizedDescription)
+                }
+            }
+        )
+    }
+
+    private func showLockedAlert() {
+        let alert = UIAlertController(
+            title: "Resource Locked",
+            message: "This resource is locked",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+
+    private func showError(_ message: String) {
+        let alert = UIAlertController(
+            title: "Download Failed",
+            message: message,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+}
+
+// MARK: - UITableViewDataSource, UITableViewDelegate
+
+extension ArtifactListViewController: UITableViewDataSource, UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return artifacts.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "ArtifactCell", for: indexPath) as! ArtifactCell
+        let artifact = artifacts[indexPath.row]
+        cell.configure(with: artifact)
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        let artifact = artifacts[indexPath.row]
+        if artifact.accessibleWithoutAttempt {
+            downloadArtifact(artifact)
+        } else {
+            showLockedAlert()
+        }
+    }
+}
+
+// MARK: - ArtifactCell
+
+private class ArtifactCell: UITableViewCell {
+
+    private let fileIconView = UIImageView()
+    private let titleLabel = UILabel()
+    private let rightIconView = UIImageView()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupViews()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupViews() {
+        backgroundColor = .white
+        contentView.backgroundColor = .white
+        selectionStyle = .none
+
+        fileIconView.translatesAutoresizingMaskIntoConstraints = false
+        fileIconView.tintColor = .systemGray
+        fileIconView.contentMode = .scaleAspectFit
+        contentView.addSubview(fileIconView)
+
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.font = UIFont.systemFont(ofSize: 16)
+        titleLabel.numberOfLines = 2
+        contentView.addSubview(titleLabel)
+
+        rightIconView.translatesAutoresizingMaskIntoConstraints = false
+        rightIconView.contentMode = .scaleAspectFit
+        contentView.addSubview(rightIconView)
+
+        NSLayoutConstraint.activate([
+            fileIconView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            fileIconView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            fileIconView.widthAnchor.constraint(equalToConstant: 24),
+            fileIconView.heightAnchor.constraint(equalToConstant: 24),
+
+            titleLabel.leadingAnchor.constraint(equalTo: fileIconView.trailingAnchor, constant: 12),
+            titleLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: rightIconView.leadingAnchor, constant: -8),
+
+            rightIconView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            rightIconView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            rightIconView.widthAnchor.constraint(equalToConstant: 24),
+            rightIconView.heightAnchor.constraint(equalToConstant: 24)
+        ])
+    }
+
+    func configure(with artifact: Artifact) {
+        titleLabel.text = artifact.name.isEmpty ? artifact.url : artifact.name
+        let isPDF = artifact.url.lowercased().hasSuffix(".pdf")
+        fileIconView.image = UIImage(systemName: isPDF ? "doc.text" : "doc")
+
+        if artifact.accessibleWithoutAttempt {
+            alpha = 1.0
+            rightIconView.image = UIImage(systemName: "arrow.down.circle")
+            rightIconView.tintColor = TestpressCourse.shared.primaryColor
+        } else {
+            alpha = 0.5
+            rightIconView.image = UIImage(systemName: "lock")
+            rightIconView.tintColor = .systemGray
+        }
+    }
+}

--- a/CourseKit/Source/UI/ViewControllers/ArtifactListViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/ArtifactListViewController.swift
@@ -93,7 +93,7 @@ extension ArtifactListViewController: UITableViewDataSource, UITableViewDelegate
 
 // MARK: - ArtifactCell
 
-private class ArtifactCell: UITableViewCell {
+class ArtifactCell: UITableViewCell {
     @IBOutlet weak var fileIconView: UIImageView!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var rightIconView: UIImageView!

--- a/CourseKit/Source/UI/ViewControllers/ArtifactListViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/ArtifactListViewController.swift
@@ -21,13 +21,13 @@ class ArtifactListViewController: BaseUIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
-        tableView.backgroundColor = .white
         setupTableView()
         emptyLabel.isHidden = !artifacts.isEmpty
         tableView.isHidden = artifacts.isEmpty
     }
 
     private func setupTableView() {
+        tableView.backgroundColor = .white
         tableView.delegate = self
         tableView.dataSource = self
         tableView.rowHeight = UITableView.automaticDimension

--- a/CourseKit/Source/UI/ViewControllers/ArtifactListViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/ArtifactListViewController.swift
@@ -18,10 +18,6 @@ class ArtifactListViewController: BaseUIViewController {
 
     var artifacts: [Artifact] = []
 
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
@@ -32,7 +28,6 @@ class ArtifactListViewController: BaseUIViewController {
     }
 
     private func setupTableView() {
-        tableView.register(ArtifactCell.self, forCellReuseIdentifier: "ArtifactCell")
         tableView.delegate = self
         tableView.dataSource = self
         tableView.rowHeight = UITableView.automaticDimension
@@ -43,19 +38,13 @@ class ArtifactListViewController: BaseUIViewController {
 
     private func downloadArtifact(_ artifact: Artifact) {
         guard let downloadUrl = URL(string: artifact.url) else {
-            showError("Invalid file URL")
+            showAlert(title: "Download Failed", message: "Invalid file URL")
             return
         }
 
-        let fileExtension = downloadUrl.pathExtension
-        let fileName: String
-        if artifact.name.isEmpty {
-            fileName = downloadUrl.lastPathComponent
-        } else if !fileExtension.isEmpty {
-            fileName = "\(artifact.name).\(fileExtension)"
-        } else {
-            fileName = artifact.name
-        }
+        let baseName = artifact.name.isEmpty ? downloadUrl.lastPathComponent : artifact.name
+        let ext = downloadUrl.pathExtension
+        let fileName = ext.isEmpty ? baseName : "\(baseName).\(ext)"
 
         FileDownloadUtility.shared.downloadFile(
             viewController: self,
@@ -63,28 +52,14 @@ class ArtifactListViewController: BaseUIViewController {
             fileName: fileName,
             completion: { [weak self] fileUrl, error in
                 if let error = error {
-                    self?.showError(error.localizedDescription)
+                    self?.showAlert(title: "Download Failed", message: error.localizedDescription)
                 }
             }
         )
     }
 
-    private func showLockedAlert() {
-        let alert = UIAlertController(
-            title: "Resource Locked",
-            message: "This resource is locked",
-            preferredStyle: .alert
-        )
-        alert.addAction(UIAlertAction(title: "OK", style: .default))
-        present(alert, animated: true)
-    }
-
-    private func showError(_ message: String) {
-        let alert = UIAlertController(
-            title: "Download Failed",
-            message: message,
-            preferredStyle: .alert
-        )
+    private func showAlert(title: String, message: String) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "OK", style: .default))
         present(alert, animated: true)
     }
@@ -111,7 +86,7 @@ extension ArtifactListViewController: UITableViewDataSource, UITableViewDelegate
         if artifact.accessibleWithoutAttempt {
             downloadArtifact(artifact)
         } else {
-            showLockedAlert()
+            showAlert(title: "Resource Locked", message: "This resource is locked")
         }
     }
 }
@@ -119,56 +94,9 @@ extension ArtifactListViewController: UITableViewDataSource, UITableViewDelegate
 // MARK: - ArtifactCell
 
 private class ArtifactCell: UITableViewCell {
-
-    private let fileIconView = UIImageView()
-    private let titleLabel = UILabel()
-    private let rightIconView = UIImageView()
-
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
-        setupViews()
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    private func setupViews() {
-        backgroundColor = .white
-        contentView.backgroundColor = .white
-        selectionStyle = .none
-
-        fileIconView.translatesAutoresizingMaskIntoConstraints = false
-        fileIconView.tintColor = .systemGray
-        fileIconView.contentMode = .scaleAspectFit
-        contentView.addSubview(fileIconView)
-
-        titleLabel.translatesAutoresizingMaskIntoConstraints = false
-        titleLabel.font = UIFont.systemFont(ofSize: 16)
-        titleLabel.numberOfLines = 2
-        contentView.addSubview(titleLabel)
-
-        rightIconView.translatesAutoresizingMaskIntoConstraints = false
-        rightIconView.contentMode = .scaleAspectFit
-        contentView.addSubview(rightIconView)
-
-        NSLayoutConstraint.activate([
-            fileIconView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
-            fileIconView.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
-            fileIconView.widthAnchor.constraint(equalToConstant: 24),
-            fileIconView.heightAnchor.constraint(equalToConstant: 24),
-
-            titleLabel.leadingAnchor.constraint(equalTo: fileIconView.trailingAnchor, constant: 12),
-            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 12),
-            titleLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -12),
-            titleLabel.trailingAnchor.constraint(equalTo: rightIconView.leadingAnchor, constant: -8),
-
-            rightIconView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
-            rightIconView.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
-            rightIconView.widthAnchor.constraint(equalToConstant: 24),
-            rightIconView.heightAnchor.constraint(equalToConstant: 24)
-        ])
-    }
+    @IBOutlet weak var fileIconView: UIImageView!
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var rightIconView: UIImageView!
 
     func configure(with artifact: Artifact) {
         titleLabel.text = artifact.name.isEmpty ? artifact.url : artifact.name

--- a/CourseKit/Source/UI/ViewControllers/ArtifactListViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/ArtifactListViewController.swift
@@ -233,16 +233,17 @@ private class ArtifactCell: UITableViewCell {
 
         NSLayoutConstraint.activate([
             fileIconView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
-            fileIconView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            fileIconView.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
             fileIconView.widthAnchor.constraint(equalToConstant: 24),
             fileIconView.heightAnchor.constraint(equalToConstant: 24),
 
             titleLabel.leadingAnchor.constraint(equalTo: fileIconView.trailingAnchor, constant: 12),
-            titleLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 12),
+            titleLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -12),
             titleLabel.trailingAnchor.constraint(equalTo: rightIconView.leadingAnchor, constant: -8),
 
             rightIconView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
-            rightIconView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            rightIconView.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
             rightIconView.widthAnchor.constraint(equalToConstant: 24),
             rightIconView.heightAnchor.constraint(equalToConstant: 24)
         ])

--- a/CourseKit/Source/UI/ViewControllers/ArtifactListViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/ArtifactListViewController.swift
@@ -9,115 +9,36 @@ import UIKit
 
 class ArtifactListViewController: BaseUIViewController {
 
-    private let tableView = UITableView()
-    private let emptyLabel = UILabel()
+    @IBOutlet weak var dragHandleView: UIView!
+    @IBOutlet weak var headerTitleLabel: UILabel!
+    @IBOutlet weak var headerSubtitleLabel: UILabel!
+    @IBOutlet weak var dividerView: UIView!
+    @IBOutlet weak var tableView: UITableView!
+    @IBOutlet weak var emptyLabel: UILabel!
 
-    // Bottom sheet header views
-    private let dragHandleView = UIView()
-    private let headerTitleLabel = UILabel()
-    private let headerSubtitleLabel = UILabel()
-    private let dividerView = UIView()
-
-    private var artifacts: [Artifact]
-
-    init(artifacts: [Artifact]) {
-        self.artifacts = artifacts
-        super.init(nibName: nil, bundle: nil)
-    }
+    var artifacts: [Artifact] = []
 
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: coder)
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
         tableView.backgroundColor = .white
-        setupHeader()
         setupTableView()
-        setupEmptyLabel()
-    }
-
-    private func setupHeader() {
-        // Drag handle
-        dragHandleView.translatesAutoresizingMaskIntoConstraints = false
-        dragHandleView.backgroundColor = .systemGray4
-        dragHandleView.layer.cornerRadius = 2.5
-        dragHandleView.clipsToBounds = true
-        view.addSubview(dragHandleView)
-
-        // Title
-        headerTitleLabel.translatesAutoresizingMaskIntoConstraints = false
-        headerTitleLabel.text = "Resources"
-        headerTitleLabel.font = UIFont.boldSystemFont(ofSize: 18)
-        headerTitleLabel.textColor = .black
-        view.addSubview(headerTitleLabel)
-
-        // Subtitle
-        headerSubtitleLabel.translatesAutoresizingMaskIntoConstraints = false
-        headerSubtitleLabel.text = "Access your study materials"
-        headerSubtitleLabel.font = UIFont.systemFont(ofSize: 14)
-        headerSubtitleLabel.textColor = .systemGray
-        view.addSubview(headerSubtitleLabel)
-
-        // Divider
-        dividerView.translatesAutoresizingMaskIntoConstraints = false
-        dividerView.backgroundColor = .systemGray5
-        view.addSubview(dividerView)
-
-        NSLayoutConstraint.activate([
-            dragHandleView.topAnchor.constraint(equalTo: view.topAnchor, constant: 8),
-            dragHandleView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            dragHandleView.widthAnchor.constraint(equalToConstant: 40),
-            dragHandleView.heightAnchor.constraint(equalToConstant: 5),
-
-            headerTitleLabel.topAnchor.constraint(equalTo: dragHandleView.bottomAnchor, constant: 16),
-            headerTitleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
-            headerTitleLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
-
-            headerSubtitleLabel.topAnchor.constraint(equalTo: headerTitleLabel.bottomAnchor, constant: 4),
-            headerSubtitleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
-            headerSubtitleLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
-
-            dividerView.topAnchor.constraint(equalTo: headerSubtitleLabel.bottomAnchor, constant: 12),
-            dividerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            dividerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            dividerView.heightAnchor.constraint(equalToConstant: 1)
-        ])
+        emptyLabel.isHidden = !artifacts.isEmpty
+        tableView.isHidden = artifacts.isEmpty
     }
 
     private func setupTableView() {
-        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.register(ArtifactCell.self, forCellReuseIdentifier: "ArtifactCell")
         tableView.delegate = self
         tableView.dataSource = self
-        tableView.register(ArtifactCell.self, forCellReuseIdentifier: "ArtifactCell")
         tableView.rowHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = 56
         tableView.tableFooterView = UIView()
         tableView.separatorInset = UIEdgeInsets(top: 0, left: 52, bottom: 0, right: 16)
-        view.addSubview(tableView)
-
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: dividerView.bottomAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        ])
-    }
-
-    private func setupEmptyLabel() {
-        emptyLabel.translatesAutoresizingMaskIntoConstraints = false
-        emptyLabel.text = "No resources available"
-        emptyLabel.textAlignment = .center
-        emptyLabel.textColor = .systemGray
-        emptyLabel.font = UIFont.systemFont(ofSize: 16)
-        emptyLabel.isHidden = !artifacts.isEmpty
-        view.addSubview(emptyLabel)
-
-        NSLayoutConstraint.activate([
-            emptyLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            emptyLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor)
-        ])
     }
 
     private func downloadArtifact(_ artifact: Artifact) {

--- a/CourseKit/Source/UI/ViewControllers/ContentDetailPageViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/ContentDetailPageViewController.swift
@@ -83,7 +83,7 @@ public class ContentDetailPageViewController: BaseUIViewController, UIPageViewCo
             setFirstViewController()
         }
 
-        enableBookmarkOption()
+        updateRightNavigationItems()
     }
     
     public override func viewDidLayoutSubviews() {
@@ -174,7 +174,7 @@ public class ContentDetailPageViewController: BaseUIViewController, UIPageViewCo
         bottomNavigationBar.isHidden = false
     }
     
-    func enableBookmarkOption() {
+    func updateRightNavigationItems() {
         if !instituteSettings.bookmarksEnabled {
             navigationBarItem.rightBarButtonItems = nil
             appendArtifactButton()
@@ -203,6 +203,9 @@ public class ContentDetailPageViewController: BaseUIViewController, UIPageViewCo
     }
 
     private func appendArtifactButton() {
+        guard let viewControllers = pageViewController.viewControllers,
+              !viewControllers.isEmpty else { return }
+
         let currentIndex = getCurrentIndex()
         guard currentIndex >= 0, currentIndex < contents.count else { return }
 
@@ -313,7 +316,7 @@ public class ContentDetailPageViewController: BaseUIViewController, UIPageViewCo
                 self?.setupContentDetailDataSource()
                 self?.setFirstViewController()
                 self?.navigationBarItem.title = content.name
-                self?.enableBookmarkOption()
+                self?.updateRightNavigationItems()
             }
         )
     }

--- a/CourseKit/Source/UI/ViewControllers/ContentDetailPageViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/ContentDetailPageViewController.swift
@@ -83,7 +83,10 @@ public class ContentDetailPageViewController: BaseUIViewController, UIPageViewCo
             setFirstViewController()
         }
 
-        updateRightNavigationItems()
+        enableBookmarkOption()
+        DispatchQueue.main.async { [weak self] in
+            self?.appendArtifactButton()
+        }
     }
     
     public override func viewDidLayoutSubviews() {
@@ -174,10 +177,9 @@ public class ContentDetailPageViewController: BaseUIViewController, UIPageViewCo
         bottomNavigationBar.isHidden = false
     }
     
-    func updateRightNavigationItems() {
+    func enableBookmarkOption() {
         if !instituteSettings.bookmarksEnabled {
             navigationBarItem.rightBarButtonItems = nil
-            appendArtifactButton()
             return
         }
 
@@ -199,7 +201,6 @@ public class ContentDetailPageViewController: BaseUIViewController, UIPageViewCo
             bookmarkButton.isEnabled = false
             bookmarkButton.image = nil
         }
-        appendArtifactButton()
     }
 
     private func appendArtifactButton() {
@@ -316,7 +317,8 @@ public class ContentDetailPageViewController: BaseUIViewController, UIPageViewCo
                 self?.setupContentDetailDataSource()
                 self?.setFirstViewController()
                 self?.navigationBarItem.title = content.name
-                self?.updateRightNavigationItems()
+                self?.enableBookmarkOption()
+                self?.appendArtifactButton()
             }
         )
     }

--- a/CourseKit/Source/UI/ViewControllers/ContentDetailPageViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/ContentDetailPageViewController.swift
@@ -392,7 +392,7 @@ public class ContentDetailPageViewController: BaseUIViewController, UIPageViewCo
 
         let url = TPEndpointProvider.getContentArtifactsUrl(contentId: contentId)
         TPApiClient.getListItems(
-            endpointProvider: TPEndpointProvider(.contentArtifacts, url: url),
+            endpointProvider: TPEndpointProvider(.get, url: url),
             headers: nil,
             completion: { [weak self] (response: TPApiResponse<Artifact>?, error: TPError?) in
                 alert.dismiss(animated: true) {
@@ -419,7 +419,9 @@ public class ContentDetailPageViewController: BaseUIViewController, UIPageViewCo
     }
 
     private func presentArtifactList(_ artifacts: [Artifact]) {
-        let vc = ArtifactListViewController(artifacts: artifacts)
+        let storyboard = UIStoryboard(name: "Course", bundle: TestpressCourse.bundle)
+        let vc = storyboard.instantiateViewController(withIdentifier: "ArtifactListViewController") as! ArtifactListViewController
+        vc.artifacts = artifacts
         vc.modalPresentationStyle = .pageSheet
 
         if #available(iOS 15.0, *) {

--- a/CourseKit/Source/UI/ViewControllers/ContentDetailPageViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/ContentDetailPageViewController.swift
@@ -175,32 +175,44 @@ public class ContentDetailPageViewController: BaseUIViewController, UIPageViewCo
     }
     
     func enableBookmarkOption() {
+        if !instituteSettings.bookmarksEnabled {
+            navigationBarItem.rightBarButtonItems = nil
+            updateArtifactButton()
+            return
+        }
+
         guard let viewControllers = pageViewController.viewControllers,
               !viewControllers.isEmpty else { return }
 
         let currentIndex = getCurrentIndex()
-        guard currentIndex >= 0, currentIndex < contents.count else { return }
+        guard currentIndex != -1 else { return }
 
-        let content = contents[currentIndex]
-        var rightItems: [UIBarButtonItem] = []
-
-        // Artifact button
-        if content.hasArtifacts {
-            rightItems.append(artifactButton)
-        }
-
-        // Bookmark button
-        if instituteSettings.bookmarksEnabled,
-           let currentVC = contentDetailDataSource.viewControllerAtIndex(currentIndex),
+        if let currentVC = contentDetailDataSource.viewControllerAtIndex(currentIndex),
            currentVC is VideoContentViewController {
+            navigationBarItem.rightBarButtonItems = [bookmarkButton]
             bookmarkButton.isEnabled = true
-            bookmarkButton.image = content.bookmarkId.value != nil
-                ? Images.RemoveBookmark.image
-                : Images.AddBookmark.image
-            rightItems.append(bookmarkButton)
+            bookmarkButton.image = Images.AddBookmark.image
+            if contents[currentIndex].bookmarkId.value != nil {
+                bookmarkButton.image = Images.RemoveBookmark.image
+            }
+        } else {
+            bookmarkButton.isEnabled = false
+            bookmarkButton.image = nil
         }
+        updateArtifactButton()
+    }
 
-        navigationBarItem.rightBarButtonItems = rightItems.isEmpty ? nil : rightItems
+    private func updateArtifactButton() {
+        let currentIndex = getCurrentIndex()
+        guard currentIndex >= 0, currentIndex < contents.count else { return }
+        let content = contents[currentIndex]
+        guard content.hasArtifacts else { return }
+
+        var items = navigationBarItem.rightBarButtonItems ?? []
+        if !items.contains(artifactButton) {
+            items.insert(artifactButton, at: 0)
+            navigationBarItem.rightBarButtonItems = items
+        }
     }
 
     // MARK: - UIPageViewController delegate methods
@@ -214,7 +226,7 @@ public class ContentDetailPageViewController: BaseUIViewController, UIPageViewCo
         if completed {
             let currentIndex = getCurrentIndex()
             updateNavigationButtons(index: currentIndex)
-            enableBookmarkOption()
+            updateArtifactButton()
         }
     }
     
@@ -298,6 +310,7 @@ public class ContentDetailPageViewController: BaseUIViewController, UIPageViewCo
                 self?.setupContentDetailDataSource()
                 self?.setFirstViewController()
                 self?.navigationBarItem.title = content.name
+                self?.enableBookmarkOption()
             }
         )
     }
@@ -390,22 +403,25 @@ public class ContentDetailPageViewController: BaseUIViewController, UIPageViewCo
         let alert = UIUtils.initProgressDialog(message: "Loading...")
         present(alert, animated: true)
 
+        fetchArtifacts(contentId: contentId) { [weak self] artifacts, error in
+            alert.dismiss(animated: true) {
+                guard let self = self else { return }
+                if let error = error {
+                    self.showArtifactError(error)
+                    return
+                }
+                self.presentArtifactList(artifacts ?? [])
+            }
+        }
+    }
+
+    private func fetchArtifacts(contentId: Int, completion: @escaping ([Artifact]?, TPError?) -> Void) {
         let url = TPEndpointProvider.getContentArtifactsUrl(contentId: contentId)
         TPApiClient.getListItems(
             endpointProvider: TPEndpointProvider(.get, url: url),
             headers: nil,
-            completion: { [weak self] (response: TPApiResponse<Artifact>?, error: TPError?) in
-                alert.dismiss(animated: true) {
-                    guard let self = self else { return }
-
-                    if let error = error {
-                        self.showArtifactError(error)
-                        return
-                    }
-
-                    let artifacts = response?.results ?? []
-                    self.presentArtifactList(artifacts)
-                }
+            completion: { (response: TPApiResponse<Artifact>?, error: TPError?) in
+                completion(response?.results, error)
             },
             type: Artifact.self
         )

--- a/CourseKit/Source/UI/ViewControllers/ContentDetailPageViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/ContentDetailPageViewController.swift
@@ -420,7 +420,7 @@ public class ContentDetailPageViewController: BaseUIViewController, UIPageViewCo
 
     private func presentArtifactList(_ artifacts: [Artifact]) {
         let storyboard = UIStoryboard(name: "Course", bundle: TestpressCourse.bundle)
-        let vc = storyboard.instantiateViewController(withIdentifier: "ArtifactListViewController") as! ArtifactListViewController
+        let vc = storyboard.instantiateViewController(withIdentifier: Constants.ARTIFACT_LIST_VIEW_CONTROLLER) as! ArtifactListViewController
         vc.artifacts = artifacts
         vc.modalPresentationStyle = .pageSheet
 

--- a/CourseKit/Source/UI/ViewControllers/ContentDetailPageViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/ContentDetailPageViewController.swift
@@ -40,6 +40,7 @@ public class ContentDetailPageViewController: BaseUIViewController, UIPageViewCo
     @IBOutlet weak var bottomNavigationBar: UIStackView!
     @IBOutlet weak var bottomNavigationBarConstraint: NSLayoutConstraint!
     @IBOutlet weak var bookmarkButton: UIBarButtonItem!
+    var artifactButton: UIBarButtonItem!
     var instituteSettings: InstituteSettings!
     
     let bottomGradient = CAGradientLayer()
@@ -65,6 +66,13 @@ public class ContentDetailPageViewController: BaseUIViewController, UIPageViewCo
         setupEmptyView()
         setupContentDetailDataSource()
         setupInitialView()
+        setupArtifactButton()
+    }
+
+    private func setupArtifactButton() {
+        let image = UIImage(systemName: "paperclip")
+        artifactButton = UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(showArtifacts))
+        artifactButton.tintColor = TestpressCourse.shared.primaryColor
     }
     
     public override func viewWillAppear(_ animated: Bool) {
@@ -167,29 +175,32 @@ public class ContentDetailPageViewController: BaseUIViewController, UIPageViewCo
     }
     
     func enableBookmarkOption() {
-        if !instituteSettings.bookmarksEnabled {
-            navigationBarItem.rightBarButtonItems = nil
-            return
-        }
-
         guard let viewControllers = pageViewController.viewControllers,
               !viewControllers.isEmpty else { return }
 
         let currentIndex = getCurrentIndex()
-        guard currentIndex != -1 else { return }
+        guard currentIndex >= 0, currentIndex < contents.count else { return }
 
-        if let currentVC = contentDetailDataSource.viewControllerAtIndex(currentIndex),
-           currentVC is VideoContentViewController {
-            navigationBarItem.rightBarButtonItems = [bookmarkButton]
-            bookmarkButton.isEnabled = true
-            bookmarkButton.image = Images.AddBookmark.image
-            if contents[currentIndex].bookmarkId.value != nil {
-                bookmarkButton.image = Images.RemoveBookmark.image
-            }
-        } else {
-            bookmarkButton.isEnabled = false
-            bookmarkButton.image = nil
+        let content = contents[currentIndex]
+        var rightItems: [UIBarButtonItem] = []
+
+        // Artifact button
+        if content.hasArtifacts {
+            rightItems.append(artifactButton)
         }
+
+        // Bookmark button
+        if instituteSettings.bookmarksEnabled,
+           let currentVC = contentDetailDataSource.viewControllerAtIndex(currentIndex),
+           currentVC is VideoContentViewController {
+            bookmarkButton.isEnabled = true
+            bookmarkButton.image = content.bookmarkId.value != nil
+                ? Images.RemoveBookmark.image
+                : Images.AddBookmark.image
+            rightItems.append(bookmarkButton)
+        }
+
+        navigationBarItem.rightBarButtonItems = rightItems.isEmpty ? nil : rightItems
     }
 
     // MARK: - UIPageViewController delegate methods
@@ -203,6 +214,7 @@ public class ContentDetailPageViewController: BaseUIViewController, UIPageViewCo
         if completed {
             let currentIndex = getCurrentIndex()
             updateNavigationButtons(index: currentIndex)
+            enableBookmarkOption()
         }
     }
     
@@ -368,6 +380,57 @@ public class ContentDetailPageViewController: BaseUIViewController, UIPageViewCo
         if let viewController = self.getCurretViewController() as? VideoContentViewController {
             viewController.addOrRemoveBookmark(content: nil)
         }
+    }
+
+    @objc func showArtifacts() {
+        let currentIndex = getCurrentIndex()
+        guard currentIndex >= 0, currentIndex < contents.count else { return }
+        let contentId = contents[currentIndex].id
+
+        let alert = UIUtils.initProgressDialog(message: "Loading...")
+        present(alert, animated: true)
+
+        let url = TPEndpointProvider.getContentArtifactsUrl(contentId: contentId)
+        TPApiClient.getListItems(
+            endpointProvider: TPEndpointProvider(.contentArtifacts, url: url),
+            headers: nil,
+            completion: { [weak self] (response: TPApiResponse<Artifact>?, error: TPError?) in
+                alert.dismiss(animated: true) {
+                    guard let self = self else { return }
+
+                    if let error = error {
+                        self.showArtifactError(error)
+                        return
+                    }
+
+                    let artifacts = response?.results ?? []
+                    self.presentArtifactList(artifacts)
+                }
+            },
+            type: Artifact.self
+        )
+    }
+
+    private func showArtifactError(_ error: TPError) {
+        let message = error.message ?? "Failed to load artifacts. Please try again."
+        let alert = UIAlertController(title: "Error", message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+
+    private func presentArtifactList(_ artifacts: [Artifact]) {
+        let vc = ArtifactListViewController(artifacts: artifacts)
+        vc.modalPresentationStyle = .pageSheet
+
+        if #available(iOS 15.0, *) {
+            if let sheet = vc.sheetPresentationController {
+                sheet.detents = [.medium(), .large()]
+                sheet.prefersGrabberVisible = true
+                sheet.preferredCornerRadius = 16
+            }
+        }
+
+        present(vc, animated: true)
     }
 }
 

--- a/CourseKit/Source/UI/ViewControllers/ContentDetailPageViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/ContentDetailPageViewController.swift
@@ -177,7 +177,7 @@ public class ContentDetailPageViewController: BaseUIViewController, UIPageViewCo
     func enableBookmarkOption() {
         if !instituteSettings.bookmarksEnabled {
             navigationBarItem.rightBarButtonItems = nil
-            updateArtifactButton()
+            appendArtifactButton()
             return
         }
 
@@ -199,19 +199,22 @@ public class ContentDetailPageViewController: BaseUIViewController, UIPageViewCo
             bookmarkButton.isEnabled = false
             bookmarkButton.image = nil
         }
-        updateArtifactButton()
+        appendArtifactButton()
     }
 
-    private func updateArtifactButton() {
+    private func appendArtifactButton() {
         let currentIndex = getCurrentIndex()
         guard currentIndex >= 0, currentIndex < contents.count else { return }
-        let content = contents[currentIndex]
-        guard content.hasArtifacts else { return }
 
         var items = navigationBarItem.rightBarButtonItems ?? []
-        if !items.contains(artifactButton) {
+        let hasArtifact = items.contains(where: { $0 === artifactButton })
+
+        if contents[currentIndex].hasArtifacts && !hasArtifact {
             items.insert(artifactButton, at: 0)
             navigationBarItem.rightBarButtonItems = items
+        } else if !contents[currentIndex].hasArtifacts && hasArtifact {
+            items.removeAll(where: { $0 === artifactButton })
+            navigationBarItem.rightBarButtonItems = items.isEmpty ? nil : items
         }
     }
 
@@ -226,7 +229,7 @@ public class ContentDetailPageViewController: BaseUIViewController, UIPageViewCo
         if completed {
             let currentIndex = getCurrentIndex()
             updateNavigationButtons(index: currentIndex)
-            updateArtifactButton()
+            appendArtifactButton()
         }
     }
     

--- a/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
@@ -393,7 +393,7 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
             contentDetailPageViewController.hideNavbarTitle()
             
             if instituteSettings.bookmarksEnabled {
-                contentDetailPageViewController.updateRightNavigationItems()
+                contentDetailPageViewController.enableBookmarkOption()
             } else {
                 contentDetailPageViewController.navigationBarItem.rightBarButtonItem = nil
             }

--- a/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
@@ -393,7 +393,7 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
             contentDetailPageViewController.hideNavbarTitle()
             
             if instituteSettings.bookmarksEnabled {
-                contentDetailPageViewController.enableBookmarkOption()
+                contentDetailPageViewController.updateRightNavigationItems()
             } else {
                 contentDetailPageViewController.navigationBarItem.rightBarButtonItem = nil
             }

--- a/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
@@ -176,11 +176,23 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
     
     func performTranscodingCheck(completion: (() -> Void)? = nil) {
         let requestedContentId = content.id
+        let url = content.getUrl()
+        
+        debugPrint("=== Transcoding Check Initiated ===")
+        debugPrint("Content ID: \(requestedContentId)")
+        debugPrint("API Endpoint URL: \(url)")
         
         TPApiClient.request(
             type: Content.self,
-            endpointProvider: TPEndpointProvider(.get, url: content.getUrl()),
+            endpointProvider: TPEndpointProvider(.get, url: url),
             completion: { [weak self] content, error in
+                debugPrint("=== Transcoding Check Completed ===")
+                debugPrint("Requested URL: \(url)")
+                if let error = error {
+                    debugPrint("Error occurred: \(error)")
+                    debugPrint("Error Message: \(error.message ?? "None")")
+                    debugPrint("Error Kind: \(error.kind)")
+                }
                 guard let self = self else { return }
                 completion?()
                 self.handleTranscodingCheckResult(requestedContentId: requestedContentId, content: content, error: error)
@@ -368,11 +380,9 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
             }
             tableView.reloadData()
             if let contentDetailPageViewController = self.parent?.parent as? ContentDetailPageViewController {
-                if bookmarkId != nil {
-                    contentDetailPageViewController.navigationBarItem.rightBarButtonItem?.image = Images.RemoveBookmark.image
-                } else {
-                    contentDetailPageViewController.navigationBarItem.rightBarButtonItem?.image = Images.AddBookmark.image
-                }
+                contentDetailPageViewController.bookmarkButton.image = bookmarkId != nil
+                    ? Images.RemoveBookmark.image
+                    : Images.AddBookmark.image
             }
         } else {
             if let cellContentId = contents.firstIndex(where: { $0.id == bookmarkContent?.id }) {
@@ -391,12 +401,7 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
         if let contentDetailPageViewController = self.parent?.parent as? ContentDetailPageViewController {
             contentDetailPageViewController.disableSwipeGesture()
             contentDetailPageViewController.hideNavbarTitle()
-            
-            if instituteSettings.bookmarksEnabled {
-                contentDetailPageViewController.enableBookmarkOption()
-            } else {
-                contentDetailPageViewController.navigationBarItem.rightBarButtonItem = nil
-            }
+            contentDetailPageViewController.enableBookmarkOption()
         }
     }
     

--- a/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
@@ -368,9 +368,11 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
             }
             tableView.reloadData()
             if let contentDetailPageViewController = self.parent?.parent as? ContentDetailPageViewController {
-                contentDetailPageViewController.bookmarkButton.image = bookmarkId != nil
-                    ? Images.RemoveBookmark.image
-                    : Images.AddBookmark.image
+                if bookmarkId != nil {
+                    contentDetailPageViewController.navigationBarItem.rightBarButtonItem?.image = Images.RemoveBookmark.image
+                } else {
+                    contentDetailPageViewController.navigationBarItem.rightBarButtonItem?.image = Images.AddBookmark.image
+                }
             }
         } else {
             if let cellContentId = contents.firstIndex(where: { $0.id == bookmarkContent?.id }) {
@@ -389,7 +391,12 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
         if let contentDetailPageViewController = self.parent?.parent as? ContentDetailPageViewController {
             contentDetailPageViewController.disableSwipeGesture()
             contentDetailPageViewController.hideNavbarTitle()
-            contentDetailPageViewController.enableBookmarkOption()
+            
+            if instituteSettings.bookmarksEnabled {
+                contentDetailPageViewController.enableBookmarkOption()
+            } else {
+                contentDetailPageViewController.navigationBarItem.rightBarButtonItem = nil
+            }
         }
     }
     

--- a/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/VideoContentViewController.swift
@@ -176,23 +176,11 @@ class VideoContentViewController: BaseUIViewController,UITableViewDelegate, UITa
     
     func performTranscodingCheck(completion: (() -> Void)? = nil) {
         let requestedContentId = content.id
-        let url = content.getUrl()
-        
-        debugPrint("=== Transcoding Check Initiated ===")
-        debugPrint("Content ID: \(requestedContentId)")
-        debugPrint("API Endpoint URL: \(url)")
         
         TPApiClient.request(
             type: Content.self,
-            endpointProvider: TPEndpointProvider(.get, url: url),
+            endpointProvider: TPEndpointProvider(.get, url: content.getUrl()),
             completion: { [weak self] content, error in
-                debugPrint("=== Transcoding Check Completed ===")
-                debugPrint("Requested URL: \(url)")
-                if let error = error {
-                    debugPrint("Error occurred: \(error)")
-                    debugPrint("Error Message: \(error.message ?? "None")")
-                    debugPrint("Error Kind: \(error.kind)")
-                }
                 guard let self = self else { return }
                 completion?()
                 self.handleTranscodingCheckResult(requestedContentId: requestedContentId, content: content, error: error)

--- a/CourseKit/Source/Utils/Constants.swift
+++ b/CourseKit/Source/Utils/Constants.swift
@@ -46,6 +46,7 @@ public struct Constants {
     public static let CONTENT_DETAIL_PAGE_VIEW_CONTROLLER = "ContentDetailPageViewController"
     public static let HTML_CONTENT_VIEW_CONTROLLER = "HtmlContentViewController"
     public static let ATTACHMENT_DETAIL_VIEW_CONTROLLER = "AttachmentDetailViewController"
+    public static let ARTIFACT_LIST_VIEW_CONTROLLER = "ArtifactListViewController"
     public static let VIDEO_CONTENT_VIEW_CONTROLLER = "VideoContentViewController"
     public static let VIDEO_CONFERENCE_VIEW_CONTROLLER = "VideoConferenceViewController"
     public static let ZOOM_MEET_VIEW_CONTROLLER = "ZoomMeetViewController"

--- a/ios-app.xcodeproj/project.pbxproj
+++ b/ios-app.xcodeproj/project.pbxproj
@@ -334,6 +334,8 @@
 		2D78B7BF2FC71046002EEE84 /* ContentPermission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D78B7BE2FC71046002EEE84 /* ContentPermission.swift */; };
 		2D7CDBCC2F237CCD0076B42F /* URLRequest+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7CDBCB2F237CCD0076B42F /* URLRequest+Extension.swift */; };
 		2D7CDBCE2F237D150076B42F /* DeviceIDManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7CDBCD2F237D150076B42F /* DeviceIDManager.swift */; };
+		2D7CDBD42F3F705F00A3B927 /* Artifact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7CDBD32F3F705F00A3B927 /* Artifact.swift */; };
+		2D7CDBD62F3F706000A3B927 /* ArtifactListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7CDBD52F3F706000A3B927 /* ArtifactListViewController.swift */; };
 		2D84D0662F433CE1000EF4DC /* UnauthorizedDeviceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D84D0652F433CE1000EF4DC /* UnauthorizedDeviceViewController.swift */; };
 		2D9597432EDEF06800E9AC7C /* OTPLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9597422EDEF06800E9AC7C /* OTPLoginViewController.swift */; };
 		2F04053220D915D90074D80E /* BookmarkFoldersDropDownCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2F04053120D915D90074D80E /* BookmarkFoldersDropDownCell.xib */; };
@@ -397,8 +399,6 @@
 		D953EB6F2CDDE90B00B62759 /* OfflineDownloadsTabController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D953EB6E2CDDE90B00B62759 /* OfflineDownloadsTabController.swift */; };
 		D9A2F2AC2CE1DFBF0052802D /* OfflineDownloadTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A2F2AB2CE1DFBF0052802D /* OfflineDownloadTableViewCell.swift */; };
 		D9CCCA5C2CF5DBA700B60B0F /* MarketingCloudSDK in Frameworks */ = {isa = PBXBuildFile; productRef = D9CCCA5B2CF5DBA700B60B0F /* MarketingCloudSDK */; };
-		2D7CDBD42F3F705F00A3B927 /* Artifact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7CDBD32F3F705F00A3B927 /* Artifact.swift */; };
-		2D7CDBD62F3F706000A3B927 /* ArtifactListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7CDBD52F3F706000A3B927 /* ArtifactListViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -605,6 +605,8 @@
 		2D78B7BE2FC71046002EEE84 /* ContentPermission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentPermission.swift; sourceTree = "<group>"; };
 		2D7CDBCB2F237CCD0076B42F /* URLRequest+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Extension.swift"; sourceTree = "<group>"; };
 		2D7CDBCD2F237D150076B42F /* DeviceIDManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceIDManager.swift; sourceTree = "<group>"; };
+		2D7CDBD32F3F705F00A3B927 /* Artifact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Artifact.swift; sourceTree = "<group>"; };
+		2D7CDBD52F3F706000A3B927 /* ArtifactListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactListViewController.swift; sourceTree = "<group>"; };
 		2D84D0652F433CE1000EF4DC /* UnauthorizedDeviceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnauthorizedDeviceViewController.swift; sourceTree = "<group>"; };
 		2D9597422EDEF06800E9AC7C /* OTPLoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPLoginViewController.swift; sourceTree = "<group>"; };
 		2F04052F20D902530074D80E /* Direction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Direction.swift; sourceTree = "<group>"; };
@@ -844,8 +846,6 @@
 		D990C7F12B31765E00B3ED4D /* DirectionTranslation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectionTranslation.swift; sourceTree = "<group>"; };
 		D9A2F2AB2CE1DFBF0052802D /* OfflineDownloadTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineDownloadTableViewCell.swift; sourceTree = "<group>"; };
 		D9D3721B2D3FB086002E9FE2 /* MobileRTC.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:BJ4HAAB9B3:Zoom Video Communications, Inc."; lastKnownFileType = wrapper.xcframework; name = MobileRTC.xcframework; path = Carthage/Build/MobileRTC.xcframework; sourceTree = "<group>"; };
-		2D7CDBD32F3F705F00A3B927 /* Artifact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Artifact.swift; sourceTree = "<group>"; };
-		2D7CDBD52F3F706000A3B927 /* ArtifactListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactListViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/ios-app.xcodeproj/project.pbxproj
+++ b/ios-app.xcodeproj/project.pbxproj
@@ -397,6 +397,8 @@
 		D953EB6F2CDDE90B00B62759 /* OfflineDownloadsTabController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D953EB6E2CDDE90B00B62759 /* OfflineDownloadsTabController.swift */; };
 		D9A2F2AC2CE1DFBF0052802D /* OfflineDownloadTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A2F2AB2CE1DFBF0052802D /* OfflineDownloadTableViewCell.swift */; };
 		D9CCCA5C2CF5DBA700B60B0F /* MarketingCloudSDK in Frameworks */ = {isa = PBXBuildFile; productRef = D9CCCA5B2CF5DBA700B60B0F /* MarketingCloudSDK */; };
+		2D7CDBD42F3F705F00A3B927 /* Artifact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7CDBD32F3F705F00A3B927 /* Artifact.swift */; };
+		2D7CDBD62F3F706000A3B927 /* ArtifactListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7CDBD52F3F706000A3B927 /* ArtifactListViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -842,6 +844,8 @@
 		D990C7F12B31765E00B3ED4D /* DirectionTranslation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectionTranslation.swift; sourceTree = "<group>"; };
 		D9A2F2AB2CE1DFBF0052802D /* OfflineDownloadTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineDownloadTableViewCell.swift; sourceTree = "<group>"; };
 		D9D3721B2D3FB086002E9FE2 /* MobileRTC.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:BJ4HAAB9B3:Zoom Video Communications, Inc."; lastKnownFileType = wrapper.xcframework; name = MobileRTC.xcframework; path = Carthage/Build/MobileRTC.xcframework; sourceTree = "<group>"; };
+		2D7CDBD32F3F705F00A3B927 /* Artifact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Artifact.swift; sourceTree = "<group>"; };
+		2D7CDBD52F3F706000A3B927 /* ArtifactListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactListViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1184,6 +1188,7 @@
 				25520BC527547006001A58AB /* DiscussionThreadAnswer.swift */,
 				25B4D0BE27B0F8BB0061D100 /* SSOUrl.swift */,
 				2F48C80E1FD2899E009C686C /* Post.swift */,
+				2D7CDBD32F3F705F00A3B927 /* Artifact.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1564,6 +1569,7 @@
 				8C04228E22AA3FD40015269B /* WebViewController.swift */,
 				D90F83662CDCD8220030C38F /* OfflineDownloadsViewController.swift */,
 				D9A2F2AB2CE1DFBF0052802D /* OfflineDownloadTableViewCell.swift */,
+				2D7CDBD52F3F706000A3B927 /* ArtifactListViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -2312,6 +2318,8 @@
 				03E4AFC82CAFCF7000ECC34D /* TPApiResponse.swift in Sources */,
 				03E4AFD62CAFE6A900ECC34D /* Constants.swift in Sources */,
 				038CB2942CBD278600164127 /* BaseQuestionsListViewController.swift in Sources */,
+				2D7CDBD42F3F705F00A3B927 /* Artifact.swift in Sources */,
+				2D7CDBD62F3F706000A3B927 /* ArtifactListViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
- Users could not access or download resources attached to course content from the content details page.
- This happened because the content details page did not provide a way to view or download the associated resources.
- This is fixed by adding a Resources option to the content details page that lists all available resources, supports downloading them, shows download progress, and clearly indicates locked resources.