### PR TITLE
fix: Hide custom module button when enableCustomTest is disabled

### DIFF
--- a/CourseKit/Source/UI/ViewControllers/CoursesTableViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/CoursesTableViewController.swift
@@ -35,6 +35,11 @@ public class CoursesTableViewController: BaseDBTableViewController<Course> {
     required init?(coder aDecoder: NSCoder) {
         super.init(pager: CoursePager(), coder: aDecoder)
     }
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        navigationItem.rightBarButtonItems = []
+    }
     
     public override func getItemsFromDb() -> [Course] {
         var courses = DBManager<Course>()
@@ -65,12 +70,10 @@ public class CoursesTableViewController: BaseDBTableViewController<Course> {
     }
     
     func showOrHideCustomTestIcon(){
-        if ((instituteSettings?.enableCustomTest ?? false)) {
-            customTestIcon.isEnabled = true
-            customTestIcon.tintColor = nil
+        if (instituteSettings?.enableCustomTest ?? false) {
+            navigationItem.rightBarButtonItems = [customTestIcon]
         } else {
-            customTestIcon.isEnabled = false
-            customTestIcon.tintColor = UIColor.clear
+            navigationItem.rightBarButtonItems = nil
         }
     }
     

--- a/CourseKit/Source/UI/ViewControllers/CoursesTableViewController.swift
+++ b/CourseKit/Source/UI/ViewControllers/CoursesTableViewController.swift
@@ -30,6 +30,7 @@ public class CoursesTableViewController: BaseDBTableViewController<Course> {
     public var tags: [String] = []
     public var excludeTags: [String] = []
     @IBOutlet weak var customTestIcon: UIBarButtonItem!
+    private var strongCustomTestIcon: UIBarButtonItem?
     var instituteSettings: InstituteSettings?
     
     required init?(coder aDecoder: NSCoder) {
@@ -38,6 +39,7 @@ public class CoursesTableViewController: BaseDBTableViewController<Course> {
 
     public override func viewDidLoad() {
         super.viewDidLoad()
+        strongCustomTestIcon = customTestIcon
         navigationItem.rightBarButtonItems = []
     }
     
@@ -71,7 +73,9 @@ public class CoursesTableViewController: BaseDBTableViewController<Course> {
     
     func showOrHideCustomTestIcon(){
         if (instituteSettings?.enableCustomTest ?? false) {
-            navigationItem.rightBarButtonItems = [customTestIcon]
+            if let icon = strongCustomTestIcon ?? customTestIcon {
+                navigationItem.rightBarButtonItems = [icon]
+            }
         } else {
             navigationItem.rightBarButtonItems = nil
         }


### PR DESCRIPTION
- Custom module button was not being hidden when enableCustomTest was false, only disabled with a clear tint
- showOrHideCustomTestIcon() set isEnabled=false and tintColor=.clear instead of removing the button from navigationItem.rightBarButtonItems. Also called in viewDidAppear causing a brief flash
- Remove button from navigationItem.rightBarButtonItems when disabled, and clear it in viewDidLoad to prevent the flash